### PR TITLE
Fix race conditions on expression task flags

### DIFF
--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -1,7 +1,8 @@
 #include "globals.h"
 #include <set>
 #include <string>
-#include <vector> 
+#include <vector>
+#include <atomic>
 
 std::set<std::string> seenDevices;
 std::vector<std::string> uuidList;
@@ -12,11 +13,11 @@ bool scanIsRunning = false;
 bool targetFound = false;
 bool hasManuData = false;
 bool skipLogging = false;
-bool isGlassesTaskRunning = false;
-bool isAngryTaskRunning = false;
-bool isSadTaskRunning = false;
-bool isHappyTaskRunning = false;
-bool isThugLifeTaskRunning = false;
+std::atomic<bool> isGlassesTaskRunning{false};
+std::atomic<bool> isAngryTaskRunning{false};
+std::atomic<bool> isSadTaskRunning{false};
+std::atomic<bool> isHappyTaskRunning{false};
+std::atomic<bool> isThugLifeTaskRunning{false};
 bool isWebLogActive = false;
 bool is_connectable = false;
 bool bleScanEnabledWeb = false;

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -5,7 +5,8 @@
 #include <set>
 #include <string>
 #include <Arduino.h>
-#include <vector> 
+#include <vector>
+#include <atomic>
 
 // ScanDevices seenDevices
 extern std::set<std::string> seenDevices;
@@ -18,11 +19,11 @@ extern bool scanIsRunning;
 extern bool targetFound;
 extern bool hasManuData;
 extern bool skipLogging;
-extern bool isGlassesTaskRunning;
-extern bool isAngryTaskRunning;
-extern bool isSadTaskRunning;
-extern bool isHappyTaskRunning;
-extern bool isThugLifeTaskRunning;
+extern std::atomic<bool> isGlassesTaskRunning;
+extern std::atomic<bool> isAngryTaskRunning;
+extern std::atomic<bool> isSadTaskRunning;
+extern std::atomic<bool> isHappyTaskRunning;
+extern std::atomic<bool> isThugLifeTaskRunning;
 extern bool isWebLogActive;
 extern bool is_connectable;
 extern bool bleScanEnabledWeb;


### PR DESCRIPTION
## Summary

- Replace plain `bool` flags with `std::atomic<bool>` for expression task state (`isGlassesTaskRunning`, `isAngryTaskRunning`, `isSadTaskRunning`, `isHappyTaskRunning`, `isThugLifeTaskRunning`)
- These flags are read/written from both the main loop and FreeRTOS worker tasks on ESP32's dual cores, requiring atomic access to prevent data races

## Changed Files

- `src/globals/globals.h` - Changed type declarations to `std::atomic<bool>`, added `<atomic>` include
- `src/globals/globals.cpp` - Changed definitions to use `std::atomic<bool>` with value initialization

## Test plan

- [ ] Verify compilation on M5Stack Cardputer target
- [ ] Confirm expression animations still trigger correctly during BLE scanning
- [ ] Verify no duplicate tasks are created under rapid scan conditions

Fixes #2