### PR TITLE
Fix BLE client memory leak when client creation fails

### DIFF
--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -340,20 +340,17 @@ void scanForDevices() {
       delay(1000);
 
       if (!pClient) { // Make sure the client was created
-        break;
+        Serial.println("⚠️ Failed to create BLE client, skipping device.");
+        continue;
       }
 
       if (seenDevices.size() >= MAX_SEEN_DEVICES) {
         seenDevices.clear();
       }
 
-      if (pClient != nullptr) {
-          pClient->setConnectTimeout(4 * 1000); // Set 4s timeout
-      } else {
-          Serial.println("⚠️ pClient is null! Cannot set connect timeout.");
-      }
+      pClient->setConnectTimeout(4 * 1000); // Set 4s timeout
 
-      if (pClient != nullptr) {
+      {
         if (is_connectable && pClient->connect(*device)) {  
           if (pClient->discoverAttributes()) {
 


### PR DESCRIPTION
## Summary

- Change `break` to `continue` when `NimBLEDevice::createClient()` returns null, so the scan continues to the next device instead of aborting entirely
- This ensures the per-iteration cleanup (disconnect + deleteClient) at the end of the loop always runs for successfully created clients
- Removes redundant null checks that were unreachable after the early `continue` guard

## Changed Files

- `src/scanner/ScanDevices.cpp` - Fix early exit path, remove dead null checks

## Test plan

- [ ] Verify scan continues when a single client creation fails
- [ ] Verify no memory growth over extended scanning sessions
- [ ] Confirm cleanup runs correctly for each device iteration

Fixes #3