### PR TITLE
Add mutex to protect WebSocket logging from concurrent tasks

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -95,6 +95,8 @@ void setup() {
 
   Serial.println("GhostBLE starting...");
 
+  initLogger();
+
   #if defined(CARDPUTER)
   M5.Lcd.setRotation(1);
   #endif

--- a/src/logToSerialAndWeb/logger.cpp
+++ b/src/logToSerialAndWeb/logger.cpp
@@ -1,11 +1,21 @@
 #include "logger.h"
 
 AsyncWebSocket ws("/ws");  // Define your AsyncWebSocket object here
+SemaphoreHandle_t logMutex = NULL;
 
+void initLogger() {
+  logMutex = xSemaphoreCreateMutex();
+}
 
 void logToSerialAndWeb(const String& msg) {
-  Serial.println(msg);
-  if (ws.count() > 0) {
-    ws.textAll(msg);
+  if (logMutex != NULL && xSemaphoreTake(logMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    Serial.println(msg);
+    if (ws.count() > 0) {
+      ws.textAll(msg);
+    }
+    xSemaphoreGive(logMutex);
+  } else {
+    // Fallback: at least write to serial if mutex unavailable
+    Serial.println(msg);
   }
 }

--- a/src/logToSerialAndWeb/logger.h
+++ b/src/logToSerialAndWeb/logger.h
@@ -5,7 +5,9 @@
 #include <ESPAsyncWebServer.h>
 
 extern AsyncWebSocket ws;
+extern SemaphoreHandle_t logMutex;
 
+void initLogger();
 void logToSerialAndWeb(const String& msg);
 
 #endif // LOGGER_H


### PR DESCRIPTION
## Summary

- Add a FreeRTOS mutex (`logMutex`) to serialize access to `Serial` and `ws.textAll()` in `logToSerialAndWeb()`
- This function is called from both the main loop and FreeRTOS worker tasks (expression animations), and `AsyncWebSocket` is not thread-safe
- Falls back to serial-only logging if the mutex cannot be acquired within 100ms, preventing worker tasks from blocking indefinitely
- Add `initLogger()` function called during `setup()` to create the mutex

## Changed Files

- `src/logToSerialAndWeb/logger.h` - Add `logMutex` extern and `initLogger()` declaration
- `src/logToSerialAndWeb/logger.cpp` - Implement mutex-protected logging with fallback
- `GhostBLE.ino` - Call `initLogger()` in `setup()`

## Test plan

- [ ] Verify compilation on M5Stack Cardputer target
- [ ] Confirm log output appears correctly on both serial and web interface
- [ ] Verify no crashes during concurrent scanning + expression animation

Fixes #4