### PR TITLE
Set SD_CS_PIN based on hardware platform

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -3,12 +3,18 @@
 
 #include <Arduino.h>
 
-// ===== SD Card Pin =====
-#define SD_CS_PIN  // Define your actual pin number here
-
 // ===== Hardware Platform =====
 //#define STICK_C_PLUS2
 #define CARDPUTER
+
+// ===== SD Card Pin =====
+#if defined(CARDPUTER)
+  #define SD_CS_PIN 12
+#elif defined(STICK_C_PLUS2)
+  #define SD_CS_PIN 14
+#else
+  #error "No hardware platform defined. Define CARDPUTER or STICK_C_PLUS2."
+#endif
 
 // ===== Flipper Zero UUIDs =====
 extern const char* FLIPPER_BLACK_UUID;


### PR DESCRIPTION
## Summary

- `SD_CS_PIN` was `#define`d without a value, expanding to nothing
- Now set automatically: pin 12 for Cardputer, pin 14 for Stick C Plus 2
- Moved platform defines before SD pin so the conditional works
- Added `#error` if no platform is defined

## Changed Files

- `src/config/config.h`

## Test plan

- [ ] Verify SD card initializes correctly on Cardputer
- [ ] Verify compile error if both platform defines are commented out

Fixes #10