### PR TITLE
Bound seenDevices set to prevent heap exhaustion

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -30,7 +30,7 @@
 
 
 unsigned long startTimeDevice;
-const unsigned long timerDurationDevice = 60 * 60 * 1000; // 60 Minuten in Millisekunden
+const unsigned long timerDurationDevice = 30 * 60 * 1000; // 30 minutes in milliseconds
 
 const char* ap_ssid = "ESP32-Log";
 const char* ap_password = "12345678";

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -82,7 +82,8 @@ void genericNotifyCallback(NimBLERemoteCharacteristic* pChar,
 
 bool isTarget = false;
 
-#define MAX_SEEN_DEVICES 1000
+#define MAX_SEEN_DEVICES 500
+#define MIN_FREE_HEAP_BYTES 20000
 
 struct IBeaconInfo {
   bool valid = false;
@@ -343,7 +344,9 @@ void scanForDevices() {
         break;
       }
 
-      if (seenDevices.size() >= MAX_SEEN_DEVICES) {
+      if (seenDevices.size() >= MAX_SEEN_DEVICES || ESP.getFreeHeap() < MIN_FREE_HEAP_BYTES) {
+        Serial.println("Clearing seenDevices (size: " + String(seenDevices.size()) +
+                        ", free heap: " + String(ESP.getFreeHeap()) + ")");
         seenDevices.clear();
       }
 


### PR DESCRIPTION
## Summary

- Reduce `MAX_SEEN_DEVICES` from 1000 to 500 to lower peak memory usage
- Add `ESP.getFreeHeap()` check that triggers early eviction when free heap drops below 20KB
- Reduce periodic clear timer from 60 to 30 minutes
- Log set size and free heap when clearing for diagnostics

## Changed Files

- `src/scanner/ScanDevices.cpp` - Reduced limit, added heap check
- `GhostBLE.ino` - Reduced timer from 60 to 30 minutes

## Test plan

- [ ] Verify seenDevices clears before heap is exhausted in busy environments
- [ ] Confirm devices are re-scanned after eviction
- [ ] Monitor serial output for clear diagnostics

Fixes #12