### PR TITLE
Remove unused global pScan variable

### DIFF
--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -19,7 +19,6 @@
 #include "../helper/BLEDecoder.h"
 
 
-NimBLEScan* pScan = nullptr;
 NimBLEClient *pClient = nullptr;
 
 // Forward declarations of required services/classes

--- a/src/scanner/ScanDevices.h
+++ b/src/scanner/ScanDevices.h
@@ -13,8 +13,6 @@
 
 #include <NimBLEDevice.h>
 
-extern NimBLEScan* pBLEScan;
-
 void startBleScan();
 void stopBleScan();
 void scanForDevices();


### PR DESCRIPTION
## Summary

- Remove unused global `NimBLEScan* pScan` from `ScanDevices.cpp` — it was shadowed by a local variable in `scanForDevices()`
- Remove unused `extern NimBLEScan* pBLEScan` declaration from `ScanDevices.h`

## Changed Files

- `src/scanner/ScanDevices.cpp` - Remove global pScan
- `src/scanner/ScanDevices.h` - Remove extern pBLEScan

## Test plan

- [ ] Verify compilation succeeds
- [ ] Confirm BLE scanning still works (uses local variable)

Fixes #13