### PR TITLE
Add destructor and end() method to SDLogger

### DIFF
--- a/src/sdCard/SDLogger.cpp
+++ b/src/sdCard/SDLogger.cpp
@@ -19,6 +19,19 @@ static const char* tierToString(ExposureTier tier)
 
 SDLogger::SDLogger() : initialized(false) {}
 
+SDLogger::~SDLogger() {
+    end();
+}
+
+void SDLogger::end() {
+    if (initialized && dataFile) {
+        dataFile.flush();
+        dataFile.close();
+        initialized = false;
+        Serial.println("#SDLogger# File closed.");
+    }
+}
+
 bool SDLogger::begin(int csPin) {
     // Initialize SD card with the correct chip select pin
     if (csPin != -1) {

--- a/src/sdCard/SDLogger.h
+++ b/src/sdCard/SDLogger.h
@@ -8,9 +8,11 @@
 class SDLogger {
 public:
     SDLogger();
+    ~SDLogger();
     bool begin(int csPin = -1); // Optional: provide CS pin
-    void writeDeviceInfo(const String& address, 
-                         const String& localName, 
+    void end();
+    void writeDeviceInfo(const String& address,
+                         const String& localName,
                          const std::vector<std::string>& nameList,
                          const String& deviceInfoString);
 


### PR DESCRIPTION
## Summary

- Add `~SDLogger()` destructor that flushes and closes the SD card file
- Add public `end()` method for explicit cleanup when needed
- Prevents data loss on unexpected resets and properly releases the file handle

## Changed Files

- `src/sdCard/SDLogger.h` - Add destructor and end() declarations
- `src/sdCard/SDLogger.cpp` - Implement destructor and end()

## Test plan

- [ ] Verify SD card logging still works after changes
- [ ] Confirm file is properly flushed before close
- [ ] Test that calling end() then begin() works for re-initialization

Fixes #14