### PR TITLE
Rename isStaticPublicMAC to isUniversallyAdministeredMAC

### DIFF
--- a/src/privacyCheck/devicePrivacy.cpp
+++ b/src/privacyCheck/devicePrivacy.cpp
@@ -99,22 +99,16 @@ bool isLikelyCleartextBytes(const std::vector<uint8_t>& bytes, size_t minLength)
 
 #include "devicePrivacy.h"
 
-bool isStaticPublicMAC(const std::string& mac)
+bool isUniversallyAdministeredMAC(const std::string& mac)
 {
-    // einfache Heuristik:
-    // Public MAC = kein Random Bit gesetzt
-    // (für GhostBLE erstmal ausreichend)
-
     if (mac.length() < 2)
         return false;
 
-    // erstes Byte der MAC
     unsigned int firstByte = std::stoi(mac.substr(0, 2), nullptr, 16);
 
-    // Bit 1 = locally administered
+    // Bit 1 (0x02) = U/L bit: 0 = universally administered, 1 = locally administered
     bool locallyAdministered = firstByte & 0x02;
 
-    // wenn nicht locally administered → public MAC
     return !locallyAdministered;
 }
 

--- a/src/privacyCheck/devicePrivacy.h
+++ b/src/privacyCheck/devicePrivacy.h
@@ -29,7 +29,7 @@ bool isRotatingMAC(MACType type);
 
 // MAC privacy
 bool isRandomMAC(const std::string& mac);
-bool isStaticPublicMAC(const std::string& mac);
+bool isUniversallyAdministeredMAC(const std::string& mac);
 String getMACPrivacyLabel(const std::string& mac);
 
 bool containsCleartext(const std::vector<uint8_t>& payload);

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -508,7 +508,7 @@ void scanForDevices() {
 
             dev.isConnectable = is_connectable;
 
-            dev.isPublicMac = isStaticPublicMAC(mac);
+            dev.isPublicMac = isUniversallyAdministeredMAC(mac);
             dev.hasStaticMac = (macType == MACType::StaticRandom);
             dev.hasRotatingMac = isRotatingMAC(macType);
 


### PR DESCRIPTION
## Summary

- Rename `isStaticPublicMAC()` to `isUniversallyAdministeredMAC()` to accurately reflect what the function checks
- The function checks the U/L bit (0x02) of the first MAC byte, which indicates universally vs locally administered — not static vs rotating
- Updated declaration in header, implementation, and call site

## Changed Files

- `src/privacyCheck/devicePrivacy.h`
- `src/privacyCheck/devicePrivacy.cpp`
- `src/scanner/ScanDevices.cpp`

## Test plan

- [ ] Verify compilation succeeds
- [ ] Confirm MAC classification still works correctly during scans

Fixes #5