### PR TITLE
Fix device classification to require combined risk signals

### DIFF
--- a/src/privacyCheck/devicePrivacy.cpp
+++ b/src/privacyCheck/devicePrivacy.cpp
@@ -136,19 +136,19 @@ DeviceCategory classifyDevice(
     bool adv_contains_cleartext,
     bool is_connectable)
 {
-    // Exposure = Informationen sichtbar
-    if (!emptyName || adv_contains_cleartext || staticPublic_mac) {
+    // Potential vulnerability: static MAC + cleartext data exposed
+    if (!rotating_mac && adv_contains_cleartext && staticPublic_mac) {
+        return DeviceCategory::POTENTIAL_VULNERABILITY;
+    }
+
+    // Uncovering: device exposes identity through multiple signals
+    if ((!emptyName && adv_contains_cleartext) || (staticPublic_mac && adv_contains_cleartext)) {
         return DeviceCategory::UNCOVERING;
     }
 
-    // Misconfiguration = unnötig offen oder schlecht konfiguriert
-    if (weakName || is_connectable) {
+    // Misconfiguration: weak name combined with open connectivity
+    if (weakName && is_connectable) {
         return DeviceCategory::MISCONFIGURATION;
-    }
-
-    // Potential vulnerability (nur Vermutung!)
-    if (!rotating_mac && adv_contains_cleartext) {
-        return DeviceCategory::POTENTIAL_VULNERABILITY;
     }
 
     return DeviceCategory::LOW_RISK;


### PR DESCRIPTION
## Summary

- Previous logic used OR conditions, flagging almost every device with a non-empty name as UNCOVERING
- Now require multiple risk signals simultaneously for each category:
  - **POTENTIAL_VULNERABILITY**: static MAC AND cleartext AND public address
  - **UNCOVERING**: (non-empty name AND cleartext) OR (public MAC AND cleartext)
  - **MISCONFIGURATION**: weak name AND connectable
- Reordered checks so highest severity is evaluated first (vulnerability before uncovering)

## Changed Files

- `src/privacyCheck/devicePrivacy.cpp` - Rewrite `classifyDevice()` conditions

## Test plan

- [ ] Verify devices with only a name are no longer flagged as UNCOVERING
- [ ] Confirm devices with cleartext + static MAC are still correctly classified
- [ ] Check that overall classification distribution is more balanced

Fixes #7