### PR TITLE
Move WiFi AP credentials to config with stronger password

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -32,8 +32,8 @@
 unsigned long startTimeDevice;
 const unsigned long timerDurationDevice = 60 * 60 * 1000; // 60 Minuten in Millisekunden
 
-const char* ap_ssid = "ESP32-Log";
-const char* ap_password = "12345678";
+const char* ap_ssid = WIFI_AP_SSID;
+const char* ap_password = WIFI_AP_PASSWORD;
 
 AsyncWebServer server(80);
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -33,6 +33,10 @@ extern const char* CATHACK_SERVICE_UUID_4;
 extern const char* CATHACK_SERVICE_UUID_5;
 extern const char* CATHACK_SERVICE_UUID_6;
 
+// ===== WiFi AP Settings =====
+#define WIFI_AP_SSID "GhostBLE"
+#define WIFI_AP_PASSWORD "ghostble123!"
+
 // ===== Time Intervals =====
 #define FACE_UPDATE_INTERVAL_MS 1000
 


### PR DESCRIPTION
## Summary

- Move hardcoded WiFi AP credentials from `GhostBLE.ino` to `src/config/config.h` as `#define` constants
- Replace weak password `12345678` with stronger `ghostble123!`
- SSID changed from `ESP32-Log` to `GhostBLE` for consistency with project name

## Changed Files

- `src/config/config.h` - Add WIFI_AP_SSID and WIFI_AP_PASSWORD defines
- `GhostBLE.ino` - Reference config defines instead of inline strings

## Test plan

- [ ] Verify WiFi AP starts with new credentials
- [ ] Confirm web interface accessible at 192.168.4.1

Fixes #15