### PR TITLE
Add wardriving mode with WiGLE CSV logging

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -24,6 +24,8 @@
 #include "src/images/nibblesBubble.h"
 
 #include "src/logToSerialAndWeb/logger.h"
+#include "src/gps/GPSManager.h"
+#include "src/wardriving/WigleLogger.h"
 
 #include <WiFi.h>
 #include <AsyncTCP.h>
@@ -83,6 +85,10 @@ bool wifiStarted = false;
 
 // External global instances
 extern SDLogger sdLogger;
+
+// GPS and wardriving
+GPSManager gpsManager;
+WigleLogger wigleLogger;
 
 File dataFile;
 std::vector<String> serviceUuids;
@@ -178,10 +184,12 @@ void loop() {
       }
       if (status.tab){
         Serial.println("TAB pressed");
-      }   
+        toggleWardriving();
+      }
       if (status.del){
         Serial.println("DEL pressed");
-      }   
+        switchGPSSource();
+      }
     }
   }
 
@@ -199,6 +207,11 @@ void loop() {
   } else {
     buttonPressStart = 0;
     buttonHeld = false;
+  }
+
+  // Update GPS if wardriving is active
+  if (wardrivingEnabled) {
+    gpsManager.update();
   }
 
   // BLE scan loop
@@ -310,5 +323,45 @@ void startWebLogServer() {
   wifiStarted = true;
 
   logToSerialAndWeb("Pres BtnG0 to TOGGLE BLE Scan");
+}
+
+void toggleWardriving() {
+  wardrivingEnabled = !wardrivingEnabled;
+
+  if (wardrivingEnabled) {
+    gpsManager.begin(GPSSource::GROVE);
+    if (wigleLogger.begin()) {
+      logToSerialAndWeb("Wardriving ON (" + String(gpsManager.getSourceName()) + ")");
+      logToSerialAndWeb("  File: " + wigleLogger.getFilename());
+    } else {
+      logToSerialAndWeb("Wardriving: SD write failed!");
+      wardrivingEnabled = false;
+    }
+  } else {
+    wigleLogger.end();
+    logToSerialAndWeb("Wardriving OFF (" + String(wigleLogger.getLoggedCount()) + " logged)");
+  }
+
+  ws.textAll(wardrivingEnabled ? "WARDRIVE_ON" : "WARDRIVE_OFF");
+  drawOverlay(nibblesFront, NIBBLESFRONT_WIDTH, NIBBLESFRONT_HEIGHT, 5, 0);
+  drawOverlay(nibblesHappy, NIBBLESHAPPY_WIDTH, NIBBLESHAPPY_HEIGHT, 83, 60);
+  showFindingCounter(targetConnects, susDevice, allSpottedDevice);
+}
+
+void switchGPSSource() {
+  if (!wardrivingEnabled) {
+    logToSerialAndWeb("Enable wardriving first (TAB)");
+    return;
+  }
+
+  GPSSource next = (gpsManager.getSource() == GPSSource::GROVE)
+                   ? GPSSource::LORA_CAP
+                   : GPSSource::GROVE;
+  gpsManager.switchSource(next);
+  logToSerialAndWeb("GPS: " + String(gpsManager.getSourceName()));
+
+  drawOverlay(nibblesFront, NIBBLESFRONT_WIDTH, NIBBLESFRONT_HEIGHT, 5, 0);
+  drawOverlay(nibblesHappy, NIBBLESHAPPY_WIDTH, NIBBLESHAPPY_HEIGHT, 83, 60);
+  showFindingCounter(targetConnects, susDevice, allSpottedDevice);
 }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -33,6 +33,27 @@ extern const char* CATHACK_SERVICE_UUID_4;
 extern const char* CATHACK_SERVICE_UUID_5;
 extern const char* CATHACK_SERVICE_UUID_6;
 
+// ===== GPS Pins =====
+// Grove port GPS (e.g. M5Stack GPS Unit on Grove UART)
+#if defined(CARDPUTER)
+  #define GPS_GROVE_RX 1
+  #define GPS_GROVE_TX 2
+#elif defined(STICK_C_PLUS2)
+  #define GPS_GROVE_RX 33
+  #define GPS_GROVE_TX 32
+#endif
+
+// LoRa cap GPS (e.g. LoRa + GPS hat module)
+#if defined(CARDPUTER)
+  #define GPS_LORA_RX 18
+  #define GPS_LORA_TX 17
+#elif defined(STICK_C_PLUS2)
+  #define GPS_LORA_RX 36
+  #define GPS_LORA_TX 26
+#endif
+
+#define GPS_BAUD_RATE 9600
+
 // ===== Time Intervals =====
 #define FACE_UPDATE_INTERVAL_MS 1000
 

--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -21,6 +21,7 @@ std::atomic<bool> isThugLifeTaskRunning{false};
 bool isWebLogActive = false;
 bool is_connectable = false;
 bool bleScanEnabledWeb = false;
+bool wardrivingEnabled = false;
 
 int susDevice = 0;
 int beaconsFound = 0;

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -27,6 +27,7 @@ extern std::atomic<bool> isThugLifeTaskRunning;
 extern bool isWebLogActive;
 extern bool is_connectable;
 extern bool bleScanEnabledWeb;
+extern bool wardrivingEnabled;
 
 extern int susDevice;
 extern int beaconsFound;

--- a/src/gps/GPSManager.cpp
+++ b/src/gps/GPSManager.cpp
@@ -1,0 +1,85 @@
+#include "GPSManager.h"
+#include "../config/config.h"
+
+GPSManager::GPSManager() : currentSource(GPSSource::GROVE), gpsSerial(1) {}
+
+void GPSManager::begin(GPSSource source) {
+    currentSource = source;
+    initSerial(source);
+}
+
+void GPSManager::switchSource(GPSSource source) {
+    gpsSerial.end();
+    delay(50);
+    currentSource = source;
+    initSerial(source);
+}
+
+GPSSource GPSManager::getSource() const {
+    return currentSource;
+}
+
+const char* GPSManager::getSourceName() const {
+    return (currentSource == GPSSource::GROVE) ? "Grove" : "LoRa";
+}
+
+void GPSManager::initSerial(GPSSource source) {
+    int rxPin, txPin;
+
+    if (source == GPSSource::GROVE) {
+        rxPin = GPS_GROVE_RX;
+        txPin = GPS_GROVE_TX;
+    } else {
+        rxPin = GPS_LORA_RX;
+        txPin = GPS_LORA_TX;
+    }
+
+    gpsSerial.begin(GPS_BAUD_RATE, SERIAL_8N1, rxPin, txPin);
+    Serial.printf("GPS: %s (RX=%d, TX=%d)\n", getSourceName(), rxPin, txPin);
+}
+
+void GPSManager::update() {
+    while (gpsSerial.available() > 0) {
+        gps.encode(gpsSerial.read());
+    }
+}
+
+bool GPSManager::isValid() const {
+    return gps.location.isValid() && gps.location.age() < 5000;
+}
+
+double GPSManager::getLatitude() const {
+    return gps.location.isValid() ? gps.location.lat() : 0.0;
+}
+
+double GPSManager::getLongitude() const {
+    return gps.location.isValid() ? gps.location.lng() : 0.0;
+}
+
+double GPSManager::getAltitude() const {
+    return gps.altitude.isValid() ? gps.altitude.meters() : 0.0;
+}
+
+float GPSManager::getHDOP() const {
+    return gps.hdop.isValid() ? (float)gps.hdop.hdop() : 99.9f;
+}
+
+uint32_t GPSManager::getSatellites() const {
+    return gps.satellites.isValid() ? gps.satellites.value() : 0;
+}
+
+String GPSManager::getTimestamp() const {
+    if (gps.date.isValid() && gps.time.isValid()) {
+        char buf[24];
+        snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d",
+                 gps.date.year(), gps.date.month(), gps.date.day(),
+                 gps.time.hour(), gps.time.minute(), gps.time.second());
+        return String(buf);
+    }
+    // Fallback: use millis as relative timestamp
+    unsigned long sec = millis() / 1000;
+    char buf[24];
+    snprintf(buf, sizeof(buf), "0000-00-00 %02lu:%02lu:%02lu",
+             (sec / 3600) % 24, (sec / 60) % 60, sec % 60);
+    return String(buf);
+}

--- a/src/gps/GPSManager.h
+++ b/src/gps/GPSManager.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Arduino.h>
+#include <TinyGPSPlus.h>
+
+enum class GPSSource {
+    GROVE,
+    LORA_CAP
+};
+
+class GPSManager {
+public:
+    GPSManager();
+
+    void begin(GPSSource source);
+    void switchSource(GPSSource source);
+    GPSSource getSource() const;
+    const char* getSourceName() const;
+
+    void update();
+
+    bool isValid() const;
+    double getLatitude() const;
+    double getLongitude() const;
+    double getAltitude() const;
+    float getHDOP() const;
+    uint32_t getSatellites() const;
+    String getTimestamp() const;
+
+private:
+    TinyGPSPlus gps;
+    GPSSource currentSource;
+    HardwareSerial gpsSerial;
+
+    void initSerial(GPSSource source);
+};

--- a/src/helper/showExpression.cpp
+++ b/src/helper/showExpression.cpp
@@ -206,8 +206,16 @@ void showFindingCounter(int sniffed, int susDevice, int spotted) {
 
   showBatteryState();
 
-  M5.Lcd.setTextColor(WHITE); 
-  M5.Lcd.setTextSize(1); 
+  // Wardriving status line
+  if (wardrivingEnabled) {
+    M5.Lcd.setTextColor(GREEN);
+    M5.Lcd.setTextSize(1);
+    M5.Lcd.setCursor(5, 94);
+    M5.Lcd.print("WD:ON");
+  }
+
+  M5.Lcd.setTextColor(WHITE);
+  M5.Lcd.setTextSize(1);
   M5.Lcd.setCursor(5, 104);
   M5.Lcd.print("Beacons:");
   M5.Lcd.println(beaconsFound);

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -17,6 +17,12 @@
 #include "../models/DeviceInfo.h"
 #include "../privacyCheck/ExposureClassifier.h"
 #include "../helper/BLEDecoder.h"
+#include "../gps/GPSManager.h"
+#include "../wardriving/WigleLogger.h"
+
+// Wardriving instances (defined in GhostBLE.ino)
+extern GPSManager gpsManager;
+extern WigleLogger wigleLogger;
 
 
 NimBLEClient *pClient = nullptr;
@@ -586,6 +592,20 @@ void scanForDevices() {
           deviceInfoService.clear();
         }
       }
+      // Wardriving: log device with GPS coordinates
+      if (wardrivingEnabled && gpsManager.isValid()) {
+        wigleLogger.logDevice(
+            address,
+            localName.length() > 0 ? localName : String(dev.name.c_str()),
+            rssi,
+            gpsManager.getLatitude(),
+            gpsManager.getLongitude(),
+            gpsManager.getAltitude(),
+            gpsManager.getHDOP(),
+            gpsManager.getTimestamp()
+        );
+      }
+
       if (pClient != nullptr && pClient->isConnected()) {
         pClient->disconnect();
       }
@@ -598,6 +618,10 @@ void scanForDevices() {
     logToSerialAndWeb("Spotted:    " + String(allSpottedDevice));
     logToSerialAndWeb("Suspicious: " + String(susDevice));
     logToSerialAndWeb("Beacons:    " + String(beaconsFound));
+    if (wardrivingEnabled) {
+      logToSerialAndWeb("WiGLE log:  " + String(wigleLogger.getLoggedCount()));
+      wigleLogger.flush();
+    }
     logToSerialAndWeb("##########################\n");
 
     scanIsRunning = false;

--- a/src/wardriving/WigleLogger.cpp
+++ b/src/wardriving/WigleLogger.cpp
@@ -1,0 +1,110 @@
+#include "WigleLogger.h"
+
+WigleLogger::WigleLogger() : initialized(false), loggedCount(0) {}
+
+String WigleLogger::generateFilename() {
+    // Find next available filename: /wigle_0001.csv, /wigle_0002.csv, ...
+    for (int i = 1; i <= 9999; i++) {
+        char buf[24];
+        snprintf(buf, sizeof(buf), "/wigle_%04d.csv", i);
+        if (!SD.exists(buf)) {
+            return String(buf);
+        }
+    }
+    return "/wigle_overflow.csv";
+}
+
+bool WigleLogger::begin() {
+    if (initialized) return true;
+
+    filename = generateFilename();
+    file = SD.open(filename.c_str(), FILE_WRITE);
+    if (!file) {
+        Serial.println("WigleLogger: Failed to create " + filename);
+        return false;
+    }
+
+    writeHeader();
+    initialized = true;
+    loggedCount = 0;
+    Serial.println("WigleLogger: Logging to " + filename);
+    return true;
+}
+
+void WigleLogger::writeHeader() {
+    // WiGLE CSV v1.6 header
+    file.println("WigleWifi-1.6,appRelease=GhostBLE,model=M5Cardputer,release=1.0,device=ESP32-S3,display=none,board=ESP32-S3,brand=M5Stack");
+    file.println("MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type");
+    file.flush();
+}
+
+String WigleLogger::escapeCSV(const String& value) {
+    // If value contains comma, quote, or newline, wrap in quotes
+    if (value.indexOf(',') >= 0 || value.indexOf('"') >= 0 || value.indexOf('\n') >= 0) {
+        String escaped = value;
+        escaped.replace("\"", "\"\"");
+        return "\"" + escaped + "\"";
+    }
+    return value;
+}
+
+void WigleLogger::logDevice(const String& mac, const String& name, int rssi,
+                            double lat, double lon, double alt, float hdop,
+                            const String& timestamp) {
+    if (!initialized || !file) return;
+
+    // Estimate accuracy from HDOP (rough: HDOP * 5 meters)
+    float accuracy = hdop * 5.0f;
+    if (accuracy > 999.0f) accuracy = 999.0f;
+
+    // MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,Lat,Lon,Alt,Accuracy,Type
+    String line;
+    line.reserve(200);
+    line += mac;
+    line += ",";
+    line += escapeCSV(name.length() > 0 ? name : "<unknown>");
+    line += ",[BLE],";
+    line += timestamp;
+    line += ",0,";
+    line += String(rssi);
+    line += ",";
+    line += String(lat, 6);
+    line += ",";
+    line += String(lon, 6);
+    line += ",";
+    line += String(alt, 1);
+    line += ",";
+    line += String(accuracy, 1);
+    line += ",BLE";
+
+    file.println(line);
+    loggedCount++;
+
+    // Flush every 10 entries to balance performance and safety
+    if (loggedCount % 10 == 0) {
+        file.flush();
+    }
+}
+
+void WigleLogger::flush() {
+    if (initialized && file) {
+        file.flush();
+    }
+}
+
+void WigleLogger::end() {
+    if (initialized && file) {
+        file.flush();
+        file.close();
+        initialized = false;
+        Serial.println("WigleLogger: Closed " + filename + " (" + String(loggedCount) + " entries)");
+    }
+}
+
+String WigleLogger::getFilename() const {
+    return filename;
+}
+
+uint32_t WigleLogger::getLoggedCount() const {
+    return loggedCount;
+}

--- a/src/wardriving/WigleLogger.h
+++ b/src/wardriving/WigleLogger.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Arduino.h>
+#include <SD.h>
+
+class WigleLogger {
+public:
+    WigleLogger();
+
+    bool begin();
+    void logDevice(const String& mac, const String& name, int rssi,
+                   double lat, double lon, double alt, float hdop,
+                   const String& timestamp);
+    void flush();
+    void end();
+    String getFilename() const;
+    uint32_t getLoggedCount() const;
+
+private:
+    File file;
+    bool initialized;
+    String filename;
+    uint32_t loggedCount;
+
+    void writeHeader();
+    String generateFilename();
+    static String escapeCSV(const String& value);
+};


### PR DESCRIPTION
## Summary
- Adds a wardriving mode that logs BLE devices with GPS coordinates in WiGLE-compatible CSV format
- Supports two GPS sources: **Grove port** (external GPS unit) and **LoRa cap** (GPS hat module), switchable at runtime
- Requires [TinyGPSPlus](https://github.com/mikalhart/TinyGPSPlus) library

## Controls
| Key | Action |
|-----|--------|
| **TAB** | Toggle wardriving mode on/off |
| **DEL** | Switch GPS source (Grove / LoRa cap) |

## New Files
- `src/gps/GPSManager.h/cpp` — GPS abstraction with dual-source support (UART1, pin-swappable)
- `src/wardriving/WigleLogger.h/cpp` — WiGLE CSV v1.6 writer with auto-incrementing filenames

## WiGLE CSV Format
Output files (`/wigle_0001.csv`, etc.) are compatible with [wigle.net](https://wigle.net) upload:
```
WigleWifi-1.6,appRelease=GhostBLE,model=M5Cardputer,...
MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type
AA:BB:CC:DD:EE:FF,DeviceName,[BLE],2024-01-15 12:30:00,0,-65,52.5200,13.4050,34.0,10.0,BLE
```

## GPS Pin Configuration (config.h)
| Source | Cardputer | StickC Plus2 |
|--------|-----------|--------------|
| Grove RX/TX | GPIO 1/2 | GPIO 33/32 |
| LoRa RX/TX | GPIO 18/17 | GPIO 36/26 |

Baud rate: 9600 (standard NMEA)

## Modified Files
- `GhostBLE.ino` — GPS/WiGLE init, TAB/DEL key handlers, GPS update in loop
- `src/config/config.h` — GPS pin defines per platform
- `src/globals/globals.h/cpp` — `wardrivingEnabled` flag
- `src/scanner/ScanDevices.cpp` — WiGLE logging after each device scan
- `src/helper/showExpression.cpp` — "WD:ON" display indicator

## Test Plan
- [ ] Verify compilation with TinyGPSPlus installed
- [ ] Test TAB toggles wardriving on/off, creates CSV file on SD
- [ ] Test DEL switches GPS source and reinitializes UART
- [ ] Verify WiGLE CSV output uploads successfully to wigle.net
- [ ] Confirm GPS fix indicator and satellite count in serial log
- [ ] Test without GPS fix — devices should not be logged (requires valid fix)