### PR TITLE
Add PwnBeacon sending and receiving

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -26,6 +26,7 @@
 #include "src/logToSerialAndWeb/logger.h"
 #include "src/gps/GPSManager.h"
 #include "src/wardriving/WigleLogger.h"
+#include "src/pwnbeacon/PwnBeacon.h"
 
 #include <WiFi.h>
 #include <AsyncTCP.h>
@@ -89,6 +90,9 @@ extern SDLogger sdLogger;
 // GPS and wardriving
 GPSManager gpsManager;
 WigleLogger wigleLogger;
+
+// PwnBeacon
+PwnBeaconManager pwnBeacon;
 
 File dataFile;
 std::vector<String> serviceUuids;
@@ -190,6 +194,12 @@ void loop() {
         Serial.println("DEL pressed");
         switchGPSSource();
       }
+      for (char c : status.word) {
+        if (c == 'p' || c == 'P') {
+          Serial.println("P pressed");
+          togglePwnBeacon();
+        }
+      }
     }
   }
 
@@ -218,7 +228,15 @@ void loop() {
   if (bleScanEnabledWeb) {
     if (currentTime - lastFaceUpdate > FACE_UPDATE_INTERVAL_MS) {
       if (!targetFound && !scanIsRunning) {
+        // Update PwnBeacon pwnd counters before scanning
+        if (pwnbeaconEnabled) {
+          pwnBeacon.setPwnd(targetConnects, allSpottedDevice);
+        }
         scanForDevices();
+        // Re-advertise after scan (scan may have interrupted advertising)
+        if (pwnbeaconEnabled) {
+          pwnBeacon.advertise();
+        }
       } else {
         targetFound = false;
       }
@@ -323,6 +341,26 @@ void startWebLogServer() {
   wifiStarted = true;
 
   logToSerialAndWeb("Pres BtnG0 to TOGGLE BLE Scan");
+}
+
+void togglePwnBeacon() {
+  pwnbeaconEnabled = !pwnbeaconEnabled;
+
+  if (pwnbeaconEnabled) {
+    // Generate a unique identity from the BLE MAC address
+    String identity = String(NimBLEDevice::getAddress().toString().c_str());
+    pwnBeacon.begin("Nibbles", identity.c_str());
+    logToSerialAndWeb("PwnBeacon ON - broadcasting as 'Nibbles'");
+  } else {
+    pwnBeacon.end();
+    pwnbeaconPeersFound = 0;
+    logToSerialAndWeb("PwnBeacon OFF (" + String(pwnBeacon.getPeerCount()) + " peers seen)");
+  }
+
+  ws.textAll(pwnbeaconEnabled ? "PWNBEACON_ON" : "PWNBEACON_OFF");
+  drawOverlay(nibblesFront, NIBBLESFRONT_WIDTH, NIBBLESFRONT_HEIGHT, 5, 0);
+  drawOverlay(nibblesHappy, NIBBLESHAPPY_WIDTH, NIBBLESHAPPY_HEIGHT, 83, 60);
+  showFindingCounter(targetConnects, susDevice, allSpottedDevice);
 }
 
 void toggleWardriving() {

--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -22,6 +22,8 @@ bool isWebLogActive = false;
 bool is_connectable = false;
 bool bleScanEnabledWeb = false;
 bool wardrivingEnabled = false;
+bool pwnbeaconEnabled = false;
+int pwnbeaconPeersFound = 0;
 
 int susDevice = 0;
 int beaconsFound = 0;

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -28,6 +28,8 @@ extern bool isWebLogActive;
 extern bool is_connectable;
 extern bool bleScanEnabledWeb;
 extern bool wardrivingEnabled;
+extern bool pwnbeaconEnabled;
+extern int pwnbeaconPeersFound;
 
 extern int susDevice;
 extern int beaconsFound;

--- a/src/helper/showExpression.cpp
+++ b/src/helper/showExpression.cpp
@@ -214,6 +214,14 @@ void showFindingCounter(int sniffed, int susDevice, int spotted) {
     M5.Lcd.print("WD:ON");
   }
 
+  // PwnBeacon status line
+  if (pwnbeaconEnabled) {
+    M5.Lcd.setTextColor(MAGENTA);
+    M5.Lcd.setTextSize(1);
+    M5.Lcd.setCursor(55, 94);
+    M5.Lcd.printf("PB:%d", pwnbeaconPeersFound);
+  }
+
   M5.Lcd.setTextColor(WHITE);
   M5.Lcd.setTextSize(1);
   M5.Lcd.setCursor(5, 104);

--- a/src/pwnbeacon/PwnBeacon.cpp
+++ b/src/pwnbeacon/PwnBeacon.cpp
@@ -1,0 +1,316 @@
+#include "PwnBeacon.h"
+#include "../logToSerialAndWeb/logger.h"
+#include <mbedtls/sha256.h>
+
+// --- Server callbacks ---
+class PwnBeaconServerCB : public NimBLEServerCallbacks {
+  void onConnect(NimBLEServer* server, NimBLEConnInfo& connInfo) override {
+    Serial.println("[PwnBeacon] Peer connected via GATT");
+    // Resume advertising so other peers can still discover us
+    NimBLEDevice::startAdvertising();
+  }
+
+  void onDisconnect(NimBLEServer* server, NimBLEConnInfo& connInfo, int reason) override {
+    Serial.println("[PwnBeacon] Peer disconnected");
+    NimBLEDevice::startAdvertising();
+  }
+};
+
+// --- Signal write callback ---
+class PwnBeaconSignalCB : public NimBLECharacteristicCallbacks {
+  void onWrite(NimBLECharacteristic* pChar, NimBLEConnInfo& connInfo) override {
+    std::string value = pChar->getValue();
+    Serial.printf("[PwnBeacon] Signal received: %s\n", value.c_str());
+  }
+};
+
+// --- PwnBeaconManager ---
+
+PwnBeaconManager::PwnBeaconManager()
+    : active(false),
+      localPwndRun(0),
+      localPwndTot(0),
+      peerCount(0),
+      bleServer(nullptr),
+      charIdentity(nullptr),
+      charFace(nullptr),
+      charName(nullptr),
+      charSignal(nullptr) {
+  memset(localName, 0, sizeof(localName));
+  memset(localIdentity, 0, sizeof(localIdentity));
+  strncpy(localFace, "(>_<)", sizeof(localFace) - 1);
+  memset(localFingerprint, 0, sizeof(localFingerprint));
+  memset(peers, 0, sizeof(peers));
+}
+
+void PwnBeaconManager::computeFingerprint(const char* id, uint8_t* out) {
+  uint8_t hash[32];
+  mbedtls_sha256((const unsigned char*)id, strlen(id), hash, 0);
+  memcpy(out, hash, PWNBEACON_FINGERPRINT_LEN);
+}
+
+void PwnBeaconManager::buildAdvPayload(uint8_t* buf, size_t* len) {
+  pwnbeacon_adv_t adv;
+  memset(&adv, 0, sizeof(adv));
+
+  adv.version  = PWNBEACON_PROTOCOL_VERSION;
+  adv.flags    = PWNBEACON_FLAG_ADVERTISE | PWNBEACON_FLAG_CONNECTABLE;
+  adv.pwnd_run = localPwndRun;
+  adv.pwnd_tot = localPwndTot;
+  memcpy(adv.fingerprint, localFingerprint, PWNBEACON_FINGERPRINT_LEN);
+
+  size_t nameLen = strlen(localName);
+  if (nameLen > PWNBEACON_ADV_MAX_NAME_LEN) {
+    nameLen = PWNBEACON_ADV_MAX_NAME_LEN;
+  }
+  adv.name_len = (uint8_t)nameLen;
+  memcpy(adv.name, localName, nameLen);
+
+  *len = offsetof(pwnbeacon_adv_t, name) + nameLen;
+  memcpy(buf, &adv, *len);
+}
+
+int PwnBeaconManager::findPeerByFingerprint(const uint8_t* fp) {
+  for (uint8_t i = 0; i < peerCount; i++) {
+    if (memcmp(peers[i].fingerprint, fp, PWNBEACON_FINGERPRINT_LEN) == 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+void PwnBeaconManager::parseAdvPayload(const uint8_t* data, size_t len, int8_t rssiVal) {
+  if (len < offsetof(pwnbeacon_adv_t, name)) {
+    return;
+  }
+
+  pwnbeacon_adv_t adv;
+  memset(&adv, 0, sizeof(adv));
+  size_t copyLen = len < sizeof(adv) ? len : sizeof(adv);
+  memcpy(&adv, data, copyLen);
+
+  if (adv.version != PWNBEACON_PROTOCOL_VERSION) {
+    return;
+  }
+
+  // Don't add ourselves
+  if (memcmp(adv.fingerprint, localFingerprint, PWNBEACON_FINGERPRINT_LEN) == 0) {
+    return;
+  }
+
+  int idx = findPeerByFingerprint(adv.fingerprint);
+
+  if (idx >= 0) {
+    // Update existing peer
+    peers[idx].rssi      = rssiVal;
+    peers[idx].last_seen = millis();
+    peers[idx].gone      = false;
+    peers[idx].pwnd_run  = adv.pwnd_run;
+    peers[idx].pwnd_tot  = adv.pwnd_tot;
+    return;
+  }
+
+  if (peerCount >= PWNBEACON_MAX_PEERS) {
+    return;
+  }
+
+  uint8_t nameLen = adv.name_len;
+  if (nameLen > PWNBEACON_ADV_MAX_NAME_LEN) {
+    nameLen = PWNBEACON_ADV_MAX_NAME_LEN;
+  }
+
+  memset(&peers[peerCount], 0, sizeof(PwnBeaconPeer));
+  peers[peerCount].name      = String(adv.name).substring(0, nameLen);
+  peers[peerCount].pwnd_run  = adv.pwnd_run;
+  peers[peerCount].pwnd_tot  = adv.pwnd_tot;
+  peers[peerCount].rssi      = rssiVal;
+  peers[peerCount].last_seen = millis();
+  peers[peerCount].gone      = false;
+  peers[peerCount].full_data = false;
+  memcpy(peers[peerCount].fingerprint, adv.fingerprint, PWNBEACON_FINGERPRINT_LEN);
+
+  lastFriendName = peers[peerCount].name;
+  peerCount++;
+
+  logToSerialAndWeb("[PwnBeacon] New peer: " + lastFriendName +
+                    " (RSSI: " + String(rssiVal) + ", pwnd: " +
+                    String(adv.pwnd_run) + "/" + String(adv.pwnd_tot) + ")");
+}
+
+String PwnBeaconManager::buildIdentityJson() {
+  String json = "{";
+  json += "\"pal\":true,";
+  json += "\"name\":\"" + String(localName) + "\",";
+  json += "\"face\":\"" + String(localFace) + "\",";
+  json += "\"epoch\":1,";
+  json += "\"grid_version\":\"2.0.0-ble\",";
+  json += "\"identity\":\"" + String(localIdentity) + "\",";
+  json += "\"pwnd_run\":" + String(localPwndRun) + ",";
+  json += "\"pwnd_tot\":" + String(localPwndTot) + ",";
+  json += "\"session_id\":\"" + String(NimBLEDevice::getAddress().toString().c_str()) + "\",";
+  json += "\"timestamp\":" + String((int)(millis() / 1000)) + ",";
+  json += "\"uptime\":" + String((int)(millis() / 1000)) + ",";
+  json += "\"version\":\"1.8.4\"";
+  json += "}";
+  return json;
+}
+
+void PwnBeaconManager::begin(const char* name, const char* identity) {
+  strncpy(localName, name, PWNBEACON_ADV_MAX_NAME_LEN);
+  localName[PWNBEACON_ADV_MAX_NAME_LEN] = '\0';
+  strncpy(localIdentity, identity, sizeof(localIdentity) - 1);
+  localIdentity[sizeof(localIdentity) - 1] = '\0';
+  computeFingerprint(identity, localFingerprint);
+
+  // NimBLE is already initialized by GhostBLE.ino — just create a server
+  bleServer = NimBLEDevice::createServer();
+  bleServer->setCallbacks(new PwnBeaconServerCB());
+
+  NimBLEService* service = bleServer->createService(PWNBEACON_SERVICE_UUID);
+
+  // Identity characteristic — full JSON payload
+  charIdentity = service->createCharacteristic(
+      PWNBEACON_IDENTITY_CHAR_UUID,
+      NIMBLE_PROPERTY::READ);
+  charIdentity->setValue(buildIdentityJson());
+
+  // Face characteristic — current mood
+  charFace = service->createCharacteristic(
+      PWNBEACON_FACE_CHAR_UUID,
+      NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
+  charFace->setValue(localFace);
+
+  // Name characteristic
+  charName = service->createCharacteristic(
+      PWNBEACON_NAME_CHAR_UUID,
+      NIMBLE_PROPERTY::READ);
+  charName->setValue(localName);
+
+  // Signal characteristic — write-only for pinging
+  charSignal = service->createCharacteristic(
+      PWNBEACON_SIGNAL_CHAR_UUID,
+      NIMBLE_PROPERTY::WRITE);
+  charSignal->setCallbacks(new PwnBeaconSignalCB());
+
+  service->start();
+
+  active = true;
+  peerCount = 0;
+  lastFriendName = "";
+
+  logToSerialAndWeb("[PwnBeacon] Initialized: " + String(name));
+  logToSerialAndWeb("[PwnBeacon] Identity fingerprint: " +
+                    String(localFingerprint[0], HEX) +
+                    String(localFingerprint[1], HEX) +
+                    String(localFingerprint[2], HEX));
+
+  // Start advertising immediately
+  advertise();
+}
+
+void PwnBeaconManager::end() {
+  if (!active) return;
+
+  stopAdvertise();
+
+  // Remove the service from the server
+  if (bleServer) {
+    bleServer->removeService(
+        bleServer->getServiceByUUID(PWNBEACON_SERVICE_UUID));
+  }
+
+  active = false;
+  peerCount = 0;
+  logToSerialAndWeb("[PwnBeacon] Stopped");
+}
+
+void PwnBeaconManager::advertise() {
+  if (!active) return;
+
+  uint8_t advData[sizeof(pwnbeacon_adv_t)];
+  size_t advLen = 0;
+  buildAdvPayload(advData, &advLen);
+
+  NimBLEAdvertising* advertising = NimBLEDevice::getAdvertising();
+  advertising->reset();
+  advertising->addServiceUUID(PWNBEACON_SERVICE_UUID);
+
+  // Set service data in scan response
+  NimBLEAdvertisementData scanResponse;
+  scanResponse.setServiceData(
+      NimBLEUUID(PWNBEACON_SERVICE_UUID),
+      std::string((char*)advData, advLen));
+  advertising->setScanResponseData(scanResponse);
+
+  advertising->start();
+}
+
+void PwnBeaconManager::stopAdvertise() {
+  NimBLEDevice::getAdvertising()->stop();
+}
+
+void PwnBeaconManager::setFace(const char* face) {
+  strncpy(localFace, face, sizeof(localFace) - 1);
+  localFace[sizeof(localFace) - 1] = '\0';
+
+  if (charFace) {
+    charFace->setValue(localFace);
+    charFace->notify();
+  }
+  if (charIdentity) {
+    charIdentity->setValue(buildIdentityJson());
+  }
+}
+
+void PwnBeaconManager::setPwnd(uint16_t run, uint16_t tot) {
+  localPwndRun = run;
+  localPwndTot = tot;
+
+  if (charIdentity) {
+    charIdentity->setValue(buildIdentityJson());
+  }
+}
+
+bool PwnBeaconManager::parseAdvertisedDevice(const NimBLEAdvertisedDevice* device) {
+  if (!active || !device) return false;
+
+  // Check if the device advertises the PwnBeacon service UUID
+  if (!device->isAdvertisingService(NimBLEUUID(PWNBEACON_SERVICE_UUID))) {
+    return false;
+  }
+
+  // Extract service data
+  std::string svcData = device->getServiceData(NimBLEUUID(PWNBEACON_SERVICE_UUID));
+  if (svcData.empty()) {
+    // Even without service data, this is still a PwnBeacon device
+    logToSerialAndWeb("[PwnBeacon] Detected peer (no adv data): " +
+                      String(device->getAddress().toString().c_str()));
+    return true;
+  }
+
+  parseAdvPayload((const uint8_t*)svcData.data(), svcData.length(),
+                  device->getRSSI());
+  return true;
+}
+
+void PwnBeaconManager::checkGonePeers() {
+  uint32_t now = millis();
+  for (uint8_t i = 0; i < peerCount; i++) {
+    if (!peers[i].gone && (now - peers[i].last_seen) > PWNBEACON_PEER_TIMEOUT_MS) {
+      peers[i].gone = true;
+      logToSerialAndWeb("[PwnBeacon] Peer gone: " + peers[i].name);
+    }
+  }
+}
+
+PwnBeaconPeer* PwnBeaconManager::getPeers() {
+  return peers;
+}
+
+uint8_t PwnBeaconManager::getPeerCount() {
+  return peerCount;
+}
+
+String PwnBeaconManager::getLastFriendName() {
+  return lastFriendName;
+}

--- a/src/pwnbeacon/PwnBeacon.h
+++ b/src/pwnbeacon/PwnBeacon.h
@@ -1,0 +1,104 @@
+#ifndef PWNBEACON_H
+#define PWNBEACON_H
+
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+
+// --- PwnBeacon Service UUIDs ---
+#define PWNBEACON_SERVICE_UUID        "b34c0000-dead-face-1337-c0deba5e0001"
+#define PWNBEACON_IDENTITY_CHAR_UUID  "b34c0000-dead-face-1337-c0deba5e0002"
+#define PWNBEACON_FACE_CHAR_UUID      "b34c0000-dead-face-1337-c0deba5e0003"
+#define PWNBEACON_NAME_CHAR_UUID      "b34c0000-dead-face-1337-c0deba5e0004"
+#define PWNBEACON_SIGNAL_CHAR_UUID    "b34c0000-dead-face-1337-c0deba5e0005"
+
+// --- Protocol constants ---
+#define PWNBEACON_PROTOCOL_VERSION  0x01
+#define PWNBEACON_ADV_MAX_NAME_LEN  8
+#define PWNBEACON_FINGERPRINT_LEN   6
+#define PWNBEACON_MAX_PEERS         16
+#define PWNBEACON_PEER_TIMEOUT_MS   120000  // 2 minutes
+
+// --- Advertisement flags ---
+#define PWNBEACON_FLAG_ADVERTISE    0x01
+#define PWNBEACON_FLAG_CONNECTABLE  0x02
+
+// --- Advertisement packet (compact binary, max 21 bytes) ---
+typedef struct __attribute__((packed)) {
+  uint8_t  version;
+  uint8_t  flags;
+  uint16_t pwnd_run;
+  uint16_t pwnd_tot;
+  uint8_t  fingerprint[PWNBEACON_FINGERPRINT_LEN];
+  uint8_t  name_len;
+  char     name[PWNBEACON_ADV_MAX_NAME_LEN];
+} pwnbeacon_adv_t;
+
+// --- Peer data ---
+struct PwnBeaconPeer {
+  String   name;
+  String   face;
+  String   identity;
+  uint16_t pwnd_run;
+  uint16_t pwnd_tot;
+  int8_t   rssi;
+  uint32_t last_seen;
+  bool     gone;
+  bool     full_data;
+  uint8_t  fingerprint[PWNBEACON_FINGERPRINT_LEN];
+};
+
+class PwnBeaconManager {
+public:
+  PwnBeaconManager();
+
+  // Initialize GATT server and advertising
+  void begin(const char* name, const char* identity);
+  void end();
+
+  // Update advertisement data and restart advertising
+  void advertise();
+  void stopAdvertise();
+
+  // Set local state
+  void setFace(const char* face);
+  void setPwnd(uint16_t run, uint16_t tot);
+
+  // Called from the existing scan loop to check a discovered device
+  bool parseAdvertisedDevice(const NimBLEAdvertisedDevice* device);
+
+  // Peer management
+  void checkGonePeers();
+  PwnBeaconPeer* getPeers();
+  uint8_t getPeerCount();
+  String getLastFriendName();
+
+  bool isActive() const { return active; }
+
+private:
+  void computeFingerprint(const char* id, uint8_t* out);
+  void buildAdvPayload(uint8_t* buf, size_t* len);
+  int  findPeerByFingerprint(const uint8_t* fp);
+  void parseAdvPayload(const uint8_t* data, size_t len, int8_t rssi);
+  String buildIdentityJson();
+
+  bool active;
+
+  char     localName[PWNBEACON_ADV_MAX_NAME_LEN + 1];
+  char     localIdentity[129];
+  char     localFace[64];
+  uint16_t localPwndRun;
+  uint16_t localPwndTot;
+  uint8_t  localFingerprint[PWNBEACON_FINGERPRINT_LEN];
+
+  PwnBeaconPeer peers[PWNBEACON_MAX_PEERS];
+  uint8_t  peerCount;
+  String   lastFriendName;
+
+  NimBLEServer*         bleServer;
+  NimBLECharacteristic* charIdentity;
+  NimBLECharacteristic* charFace;
+  NimBLECharacteristic* charName;
+  NimBLECharacteristic* charSignal;
+};
+
+#endif // PWNBEACON_H

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -19,10 +19,14 @@
 #include "../helper/BLEDecoder.h"
 #include "../gps/GPSManager.h"
 #include "../wardriving/WigleLogger.h"
+#include "../pwnbeacon/PwnBeacon.h"
 
 // Wardriving instances (defined in GhostBLE.ino)
 extern GPSManager gpsManager;
 extern WigleLogger wigleLogger;
+
+// PwnBeacon instance (defined in GhostBLE.ino)
+extern PwnBeaconManager pwnBeacon;
 
 
 NimBLEClient *pClient = nullptr;
@@ -268,6 +272,12 @@ void scanForDevices() {
           continue;
         }
         seenDevices.insert(std::string(address.c_str()));
+
+        // Check for PwnBeacon advertisement
+        if (pwnbeaconEnabled && pwnBeacon.parseAdvertisedDevice(device)) {
+          pwnbeaconPeersFound = pwnBeacon.getPeerCount();
+          logToSerialAndWeb("👾 PwnBeacon peer detected: " + String(device->getAddress().toString().c_str()));
+        }
 
         // Risk factor: Weak/default device name
         if (localName == "< -- >" || localName == "BLE Device" || localName == "Random") {
@@ -618,6 +628,10 @@ void scanForDevices() {
     logToSerialAndWeb("Spotted:    " + String(allSpottedDevice));
     logToSerialAndWeb("Suspicious: " + String(susDevice));
     logToSerialAndWeb("Beacons:    " + String(beaconsFound));
+    if (pwnbeaconEnabled) {
+      pwnBeacon.checkGonePeers();
+      logToSerialAndWeb("PwnPeers:   " + String(pwnBeacon.getPeerCount()));
+    }
     if (wardrivingEnabled) {
       logToSerialAndWeb("WiGLE log:  " + String(wigleLogger.getLoggedCount()));
       wigleLogger.flush();

--- a/src/target/TargetDevice.cpp
+++ b/src/target/TargetDevice.cpp
@@ -28,7 +28,13 @@ bool isTargetDevice(String name, String address, String serviceUuid, String devi
     return true;
   }
 
-  // 3. FLIPPER ZERO UUIDs
+  // 3. PWNAGOTCHI / PwnBeacon
+  if (serviceUuid == "b34c0000-dead-face-1337-c0deba5e0001") {
+    Serial.println("👾 PWNAGOTCHI detected (PwnBeacon)");
+    return true;
+  }
+
+  // 4. FLIPPER ZERO UUIDs
   if (serviceUuid == FLIPPER_BLACK_UUID) {
     Serial.println("🐬 FLIPPER ZERO detected (Black)");
     return true;


### PR DESCRIPTION
## Summary
- Integrates the PwnBeacon BLE protocol (adapted for NimBLE) for Pwnagotchi mesh networking
- GhostBLE can now advertise as a PwnBeacon peer ("Nibbles") and discover nearby Pwnagotchi devices
- Detected PwnBeacon devices are also flagged as target devices in the scan loop

## Details
**New files:** `src/pwnbeacon/PwnBeacon.h`, `src/pwnbeacon/PwnBeacon.cpp`

**Sending:** Sets up a GATT server with Identity (JSON), Face, Name, and Signal characteristics. Broadcasts a compact binary advertisement (max 21 bytes) with version, flags, pwnd counters, identity fingerprint (SHA-256), and name.

**Receiving:** During each scan cycle, every discovered device is checked for the PwnBeacon service UUID. Peers are tracked with 2-minute timeout, up to 16 peers max.

**Controls:** Press `P` to toggle PwnBeacon on/off. Status shown as `PB:<count>` in magenta on the LCD.

## Test plan
- [ ] Verify PwnBeacon toggle with P key enables/disables advertising
- [ ] Confirm GATT server starts and characteristics are readable
- [ ] Test peer discovery with a real Pwnagotchi or second PwnBeacon device
- [ ] Verify PwnBeacon devices are flagged as targets in scan results
- [ ] Check LCD status bar shows `PB:<count>` when active
- [ ] Ensure existing BLE scanning still works normally with PwnBeacon enabled