### PR TITLE
Store all data in /GhostBLE/ folder on SD card

### DIFF
--- a/src/sdCard/SDLogger.cpp
+++ b/src/sdCard/SDLogger.cpp
@@ -32,6 +32,33 @@ void SDLogger::end() {
     }
 }
 
+void SDLogger::migrateToFolder() {
+    // Migrate legacy root-level files into /GhostBLE/ folder.
+    // Only called when /GhostBLE/ doesn't exist yet.
+    SD.mkdir("/GhostBLE");
+    Serial.println("#SDLogger# Created /GhostBLE folder, migrating legacy files...");
+
+    if (SD.exists("/device_info.txt")) {
+        SD.rename("/device_info.txt", "/GhostBLE/device_info.txt");
+        Serial.println("#SDLogger# Migrated /device_info.txt");
+    }
+
+    for (int i = 1; i <= 9999; i++) {
+        char oldPath[24];
+        snprintf(oldPath, sizeof(oldPath), "/wigle_%04d.csv", i);
+        if (!SD.exists(oldPath)) break;
+        char newPath[34];
+        snprintf(newPath, sizeof(newPath), "/GhostBLE/wigle_%04d.csv", i);
+        SD.rename(oldPath, newPath);
+        Serial.printf("#SDLogger# Migrated %s\n", oldPath);
+    }
+
+    if (SD.exists("/wigle_overflow.csv")) {
+        SD.rename("/wigle_overflow.csv", "/GhostBLE/wigle_overflow.csv");
+        Serial.println("#SDLogger# Migrated /wigle_overflow.csv");
+    }
+}
+
 bool SDLogger::begin(int csPin) {
     // Initialize SD card with the correct chip select pin
     if (csPin != -1) {
@@ -46,15 +73,20 @@ bool SDLogger::begin(int csPin) {
         }
     }
 
+    // Create folder and migrate legacy files on first run
+    if (!SD.exists("/GhostBLE")) {
+        migrateToFolder();
+    }
+
     // Try opening the file with a check for success
-    dataFile = SD.open("/device_info.txt", FILE_APPEND);  // Try without leading "/"
+    dataFile = SD.open("/GhostBLE/device_info.txt", FILE_APPEND);
     if (!dataFile) {
-        Serial.println("#SDLogger# Error opening /device_info.txt for writing.");
+        Serial.println("#SDLogger# Error opening /GhostBLE/device_info.txt for writing.");
         return false;
     }
 
     // Log success and set initialization flag
-    Serial.println("#SDLogger# /device_info.txt opened successfully.");
+    Serial.println("#SDLogger# /GhostBLE/device_info.txt opened successfully.");
     initialized = true;
     return true;
 }

--- a/src/sdCard/SDLogger.h
+++ b/src/sdCard/SDLogger.h
@@ -31,4 +31,5 @@ public:
 private:
     File dataFile;
     bool initialized;
+    void migrateToFolder();
 };

--- a/src/wardriving/WigleLogger.cpp
+++ b/src/wardriving/WigleLogger.cpp
@@ -3,15 +3,15 @@
 WigleLogger::WigleLogger() : initialized(false), loggedCount(0) {}
 
 String WigleLogger::generateFilename() {
-    // Find next available filename: /wigle_0001.csv, /wigle_0002.csv, ...
+    // Find next available filename in /GhostBLE/ folder
     for (int i = 1; i <= 9999; i++) {
-        char buf[24];
-        snprintf(buf, sizeof(buf), "/wigle_%04d.csv", i);
+        char buf[34];
+        snprintf(buf, sizeof(buf), "/GhostBLE/wigle_%04d.csv", i);
         if (!SD.exists(buf)) {
             return String(buf);
         }
     }
-    return "/wigle_overflow.csv";
+    return "/GhostBLE/wigle_overflow.csv";
 }
 
 bool WigleLogger::begin() {


### PR DESCRIPTION
## Summary
- All SD card data is now written to `/GhostBLE/` instead of the root, avoiding collisions with other firmware
- On first run (when `/GhostBLE/` doesn't exist), legacy root-level files (`device_info.txt`, `wigle_*.csv`) are automatically migrated into the folder
- Subsequent boots skip migration entirely — just a single `SD.exists()` check

## Test plan
- [ ] Flash and boot with existing root-level data files on SD — verify they get moved to `/GhostBLE/`
- [ ] Reboot and verify migration doesn't run again
- [ ] Verify BLE scanning writes `device_info.txt` to `/GhostBLE/`
- [ ] Verify wardriving creates CSV files in `/GhostBLE/`