### PR TITLE
Add XP/Level system with Nibbles titles

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -134,8 +134,10 @@ void setup() {
   }
   #endif
 
-  M5.Lcd.setTextColor(BLACK); 
-  M5.Lcd.setTextSize(1); 
+  xpManager.begin();
+
+  M5.Lcd.setTextColor(BLACK);
+  M5.Lcd.setTextSize(1);
   M5.Lcd.setCursor(136, 27);
   M5.Lcd.println("HI I'M NIBBLES");
   vTaskDelay(pdMS_TO_TICKS(2000));

--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <atomic>
 
+XPManager xpManager;
+
 std::set<std::string> seenDevices;
 std::vector<std::string> uuidList;
 std::vector<std::string> nameList;

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -8,6 +8,10 @@
 #include <vector>
 #include <atomic>
 
+#include "../xp/XPManager.h"
+
+extern XPManager xpManager;
+
 // ScanDevices seenDevices
 extern std::set<std::string> seenDevices;
 extern std::vector<std::string> uuidList;

--- a/src/helper/BLEDecoder.cpp
+++ b/src/helper/BLEDecoder.cpp
@@ -1,6 +1,7 @@
 #include "BLEDecoder.h"
 #include "../logToSerialAndWeb/logger.h"
 #include "../sdCard/SDLogger.h"
+#include "../globals/globals.h"
 #include <string>
 
 // Forward declarations of required services/classes
@@ -42,6 +43,8 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
     String hexString   = toHex(data, length);
     String asciiString = toASCII(data, length);
 
+    xpManager.awardXP(15);  // +15 XP: notify data received
+
     // ---- Pretty Output (Serial/Web) ----
     logToSerialAndWeb("BLE Notify");
     logToSerialAndWeb("   UUID : " + uuidStr);
@@ -61,6 +64,7 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
     // ---- Known BLE characteristics ----
     if (uuidStr.endsWith("2a19") && length >= 1)
     {
+        xpManager.awardXP(25);  // +25 XP: known char decoded (battery)
         String battery = String(data[0]) + "%";
 
         logToSerialAndWeb("   Battery Level: " + battery);
@@ -79,6 +83,7 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
 
     if (uuidStr.endsWith("2a00"))
     {
+        xpManager.awardXP(25);  // +25 XP: known char decoded (name)
         String name = asciiString;
 
         logToSerialAndWeb("   Device Name: " + name);
@@ -89,6 +94,7 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
     // ---- UINT16 detection ----
     if (length % 2 == 0 && length <= 16)
     {
+        xpManager.awardXP(10);  // +10 XP: UINT payload decoded
         String values = "";
 
         for (size_t i = 0; i < length; i += 2)
@@ -130,6 +136,7 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
     // ---- FLOAT32 detection ----
     if (length == 4)
     {
+        xpManager.awardXP(10);  // +10 XP: FLOAT payload decoded
         float f;
         memcpy(&f, data, 4);
 

--- a/src/helper/showExpression.cpp
+++ b/src/helper/showExpression.cpp
@@ -209,6 +209,26 @@ void showFindingCounter(int sniffed, int susDevice, int spotted) {
     M5.Lcd.print("WD:ON");
   }
 
+  // XP Level and progress bar
+  M5.Lcd.setTextColor(GREEN);
+  M5.Lcd.setTextSize(1);
+  M5.Lcd.setCursor(5, 94);
+  M5.Lcd.printf("LVL:%u", xpManager.getLevel());
+
+  // Progress bar outline
+  int barX = 55, barY = 94, barW = 60, barH = 7;
+  M5.Lcd.drawRect(barX, barY, barW, barH, GREEN);
+  // Progress bar fill
+  int fillW = (barW - 2) * xpManager.getProgressPercent() / 100;
+  if (fillW > 0) {
+    M5.Lcd.fillRect(barX + 1, barY + 1, fillW, barH - 2, GREEN);
+  }
+
+  // Nibbles title
+  M5.Lcd.setTextColor(GREEN);
+  M5.Lcd.setCursor(120, 94);
+  M5.Lcd.print(xpManager.getTitle());
+
   M5.Lcd.setTextColor(WHITE);
   M5.Lcd.setTextSize(1);
   M5.Lcd.setCursor(5, 104);

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -44,10 +44,13 @@ void subscribeToAllNotifications(NimBLEClient* client, Callback notifyCallback) 
           if (!characteristic) continue;
           if (characteristic->canNotify()) 
           {
-            if (characteristic->canNotify())
+            if (characteristic->canNotify()) {
                 characteristic->subscribe(true, notifyCallback);
-            else if (characteristic->canIndicate())
+                xpManager.awardXP(10);  // +10 XP: characteristic subscription
+            } else if (characteristic->canIndicate()) {
                 characteristic->subscribe(false, notifyCallback);
+                xpManager.awardXP(10);  // +10 XP: characteristic subscription
+            }
             if (characteristic->canRead()) {
                 std::string val = characteristic->readValue();
                 logToSerialAndWeb(("   Read value length: " + String(val.length())).c_str());
@@ -284,11 +287,13 @@ void scanForDevices() {
           std::string mfg = device->getManufacturerData();
           manufacturerId = (uint8_t)mfg[1] << 8 | (uint8_t)mfg[0];
           manufacturerName = getManufacturerName(manufacturerId);
+          xpManager.awardXP(2);  // +2 XP: manufacturer data decoded
 
           // Detect iBeacon
           beacon = parseIBeacon(mfg);
           if (beacon.valid) {
             isIBeacon = true;
+            xpManager.awardXP(3);  // +3 XP: iBeacon parsed
             logToSerialAndWeb("iBeacon detected!");
             logToSerialAndWeb("   UUID:  " + String(beacon.uuid.c_str()));
             logToSerialAndWeb("   Major: " + String(beacon.major));
@@ -336,6 +341,7 @@ void scanForDevices() {
 
       isTarget = false;
       allSpottedDevice++;
+      xpManager.awardXP(1);  // +1 XP: new device discovered
 
       // Print device connectability
       if (!is_connectable) {
@@ -374,6 +380,7 @@ void scanForDevices() {
 
             logToSerialAndWeb("🔓 Connected and discovered attributes!");
             targetConnects++;
+            xpManager.awardXP(5);  // +5 XP: GATT connection success
 
             if (!isGlassesTaskRunning && !isAngryTaskRunning) {
               xTaskCreatePinnedToCore(showGlassesExpressionTask, "BLEGlasses", 4096, NULL, 0, &glassesTaskHandle, 1);
@@ -443,6 +450,7 @@ void scanForDevices() {
               if (isTargetDevice(localName.c_str(), address.c_str(), serviceUuid.c_str(), deviceInfoService.c_str())) {
                 targetFound = true;
                 susDevice++;
+                xpManager.awardXP(20);  // +20 XP: suspicious device found
                 logToSerialAndWeb("Target Message: !!! Target detected !!!");
                 vTaskDelay(pdMS_TO_TICKS(2000));
                 if (!isAngryTaskRunning) {
@@ -618,6 +626,7 @@ void scanForDevices() {
     }
     logToSerialAndWeb("##########################\n");
 
+    xpManager.save();
     scanIsRunning = false;
   }
 }

--- a/src/xp/XPManager.cpp
+++ b/src/xp/XPManager.cpp
@@ -1,0 +1,104 @@
+#include "XPManager.h"
+#include <math.h>
+
+static const char* XP_FILE = "/GhostBLE/xp.dat";
+
+void XPManager::begin() {
+    File f = SD.open(XP_FILE, FILE_READ);
+    if (f) {
+        XPData data;
+        if (f.read((uint8_t*)&data, sizeof(data)) == sizeof(data) && data.magic == XP_MAGIC) {
+            totalXP = data.totalXP;
+            currentLevel = data.currentLevel;
+            Serial.printf("XP loaded: %u XP, LVL %u\n", totalXP, currentLevel);
+        } else {
+            Serial.println("XP file invalid, starting fresh");
+        }
+        f.close();
+    } else {
+        Serial.println("No XP file found, starting at LVL 1");
+    }
+    recalculateLevel();
+    lastSaveTime = millis();
+}
+
+void XPManager::awardXP(uint16_t amount) {
+    totalXP += amount;
+    dirty = true;
+
+    uint16_t oldLevel = currentLevel;
+    recalculateLevel();
+
+    if (currentLevel > oldLevel) {
+        Serial.printf("LEVEL UP! LVL %u -> %u (XP: %u)\n", oldLevel, currentLevel, totalXP);
+        save();  // Force save on level-up
+    }
+}
+
+void XPManager::save() {
+    if (!dirty) return;
+
+    unsigned long now = millis();
+    if (now - lastSaveTime < XP_SAVE_INTERVAL) return;
+
+    XPData data;
+    data.magic = XP_MAGIC;
+    data.totalXP = totalXP;
+    data.currentLevel = currentLevel;
+
+    File f = SD.open(XP_FILE, FILE_WRITE);
+    if (f) {
+        f.write((uint8_t*)&data, sizeof(data));
+        f.close();
+        dirty = false;
+        lastSaveTime = now;
+        Serial.printf("XP saved: %u XP, LVL %u\n", totalXP, currentLevel);
+    }
+}
+
+uint16_t XPManager::getLevel() {
+    return currentLevel;
+}
+
+uint32_t XPManager::getXP() {
+    return totalXP;
+}
+
+uint8_t XPManager::getProgressPercent() {
+    uint32_t currentLevelXP = xpForLevel(currentLevel);
+    uint32_t nextLevelXP = xpForLevel(currentLevel + 1);
+    uint32_t range = nextLevelXP - currentLevelXP;
+    if (range == 0) return 100;
+    uint32_t progress = totalXP - currentLevelXP;
+    return (uint8_t)((progress * 100) / range);
+}
+
+uint32_t XPManager::xpForLevel(uint16_t level) {
+    if (level <= 1) return 0;
+    return (uint32_t)floor(16.67 * pow((double)level, 1.477));
+}
+
+void XPManager::recalculateLevel() {
+    while (totalXP >= xpForLevel(currentLevel + 1)) {
+        currentLevel++;
+    }
+}
+
+const char* XPManager::getTitle() {
+    uint16_t lvl = currentLevel;
+    if (lvl >= 500) return "BLE Deity";
+    if (lvl >= 300) return "Phantom Lord";
+    if (lvl >= 200) return "Ghost King";
+    if (lvl >= 150) return "Ether Wraith";
+    if (lvl >= 100) return "Packet Overlord";
+    if (lvl >= 75)  return "Signal Sorcerer";
+    if (lvl >= 50)  return "Byte Bandit";
+    if (lvl >= 35)  return "Freq Fiend";
+    if (lvl >= 25)  return "Sniff Lord";
+    if (lvl >= 18)  return "Air Pirate";
+    if (lvl >= 12)  return "Beacon Hunter";
+    if (lvl >= 8)   return "Data Gremlin";
+    if (lvl >= 5)   return "Sniff Puppy";
+    if (lvl >= 3)   return "Bit Curious";
+    return "Clueless Ghost";
+}

--- a/src/xp/XPManager.h
+++ b/src/xp/XPManager.h
@@ -1,0 +1,37 @@
+#ifndef XP_MANAGER_H
+#define XP_MANAGER_H
+
+#include <Arduino.h>
+#include <SD.h>
+
+#define XP_MAGIC 0x58504C56
+#define XP_SAVE_INTERVAL 60000  // 60 seconds
+
+class XPManager {
+public:
+    void begin();
+    void awardXP(uint16_t amount);
+    void save();
+
+    uint16_t getLevel();
+    uint32_t getXP();
+    uint8_t getProgressPercent();
+    const char* getTitle();
+
+private:
+    struct __attribute__((packed)) XPData {
+        uint32_t magic;
+        uint32_t totalXP;
+        uint16_t currentLevel;
+    };
+
+    uint32_t totalXP = 0;
+    uint16_t currentLevel = 1;
+    unsigned long lastSaveTime = 0;
+    bool dirty = false;
+
+    uint32_t xpForLevel(uint16_t level);
+    void recalculateLevel();
+};
+
+#endif


### PR DESCRIPTION
## Summary
- Adds persistent XP/Level system stored as binary on SD card (`/GhostBLE/xp.dat`)
- Awards XP for BLE scanning events (device discovery, GATT connects, notifications, suspicious finds)
- Displays level, XP progress bar, and fun Nibbles titles on screen (e.g. "Clueless Ghost" → "Sniff Puppy" → "BLE Deity")
- XP survives reboots via SD card persistence with magic number validation

Closes #39

## Test plan
- [ ] Compile for M5Stack Cardputer
- [ ] Verify LVL:1 and "Clueless Ghost" display at boot
- [ ] Run BLE scan — confirm XP increments in serial log
- [ ] Check `/GhostBLE/xp.dat` created on SD after first scan cycle
- [ ] Reboot — verify level persists
- [ ] Scan enough to level up — verify title changes and progress bar fills