### PR TITLE
Show GPS status on screen and fix empty WiGLE CSV files

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -321,13 +321,9 @@ void toggleWardriving() {
 
   if (wardrivingEnabled) {
     gpsManager.begin(GPSSource::GROVE);
-    if (wigleLogger.begin()) {
-      logToSerialAndWeb("Wardriving ON (" + String(gpsManager.getSourceName()) + ")");
-      logToSerialAndWeb("  File: " + wigleLogger.getFilename());
-    } else {
-      logToSerialAndWeb("Wardriving: SD write failed!");
-      wardrivingEnabled = false;
-    }
+    wigleLogger.begin();
+    logToSerialAndWeb("Wardriving ON (" + String(gpsManager.getSourceName()) + ")");
+    logToSerialAndWeb("  File: " + wigleLogger.getFilename());
   } else {
     wigleLogger.end();
     logToSerialAndWeb("Wardriving OFF (" + String(wigleLogger.getLoggedCount()) + " logged)");

--- a/src/helper/showExpression.cpp
+++ b/src/helper/showExpression.cpp
@@ -14,6 +14,7 @@
 #include "../images/nibblesHeartRight.h"
 #include "../images/nibblesThugLife.h"
 #include "src/images/nibblesBubble.h"
+#include "../gps/GPSManager.h"
 
 static float smoothedVoltage = 0;
 static int displayedPercent = 100;
@@ -207,6 +208,19 @@ void showFindingCounter(int sniffed, int susDevice, int spotted) {
     M5.Lcd.setTextSize(1);
     M5.Lcd.setCursor(5, 20);
     M5.Lcd.print("WD:ON");
+  }
+
+  // GPS status line (shown when wardriving is active)
+  if (wardrivingEnabled) {
+    extern GPSManager gpsManager;
+    bool hasFix = gpsManager.isValid();
+    M5.Lcd.setTextSize(1);
+    M5.Lcd.setCursor(55, 20);
+    M5.Lcd.setTextColor(hasFix ? GREEN : RED);
+    M5.Lcd.printf("GPS:%s %s SAT:%u",
+        gpsManager.getSourceName(),
+        hasFix ? "FIX" : "NO FIX",
+        gpsManager.getSatellites());
   }
 
   // XP Level and progress bar

--- a/src/wardriving/WigleLogger.cpp
+++ b/src/wardriving/WigleLogger.cpp
@@ -1,6 +1,6 @@
 #include "WigleLogger.h"
 
-WigleLogger::WigleLogger() : initialized(false), loggedCount(0) {}
+WigleLogger::WigleLogger() : active(false), initialized(false), loggedCount(0) {}
 
 String WigleLogger::generateFilename() {
     // Find next available filename in /GhostBLE/ folder
@@ -14,7 +14,13 @@ String WigleLogger::generateFilename() {
     return "/GhostBLE/wigle_overflow.csv";
 }
 
-bool WigleLogger::begin() {
+void WigleLogger::begin() {
+    active = true;
+    loggedCount = 0;
+    Serial.println("WigleLogger: Ready (file created on first GPS fix)");
+}
+
+bool WigleLogger::openFile() {
     if (initialized) return true;
 
     filename = generateFilename();
@@ -26,7 +32,6 @@ bool WigleLogger::begin() {
 
     writeHeader();
     initialized = true;
-    loggedCount = 0;
     Serial.println("WigleLogger: Logging to " + filename);
     return true;
 }
@@ -51,7 +56,10 @@ String WigleLogger::escapeCSV(const String& value) {
 void WigleLogger::logDevice(const String& mac, const String& name, int rssi,
                             double lat, double lon, double alt, float hdop,
                             const String& timestamp) {
-    if (!initialized || !file) return;
+    if (!active) return;
+
+    // Lazily create the file on first device log (only when GPS is valid)
+    if (!initialized && !openFile()) return;
 
     // Estimate accuracy from HDOP (rough: HDOP * 5 meters)
     float accuracy = hdop * 5.0f;
@@ -96,15 +104,20 @@ void WigleLogger::end() {
     if (initialized && file) {
         file.flush();
         file.close();
-        initialized = false;
         Serial.println("WigleLogger: Closed " + filename + " (" + String(loggedCount) + " entries)");
     }
+    initialized = false;
+    active = false;
 }
 
 String WigleLogger::getFilename() const {
-    return filename;
+    return initialized ? filename : "(waiting for GPS)";
 }
 
 uint32_t WigleLogger::getLoggedCount() const {
     return loggedCount;
+}
+
+bool WigleLogger::isReady() const {
+    return active;
 }

--- a/src/wardriving/WigleLogger.h
+++ b/src/wardriving/WigleLogger.h
@@ -7,7 +7,7 @@ class WigleLogger {
 public:
     WigleLogger();
 
-    bool begin();
+    void begin();
     void logDevice(const String& mac, const String& name, int rssi,
                    double lat, double lon, double alt, float hdop,
                    const String& timestamp);
@@ -15,13 +15,16 @@ public:
     void end();
     String getFilename() const;
     uint32_t getLoggedCount() const;
+    bool isReady() const;
 
 private:
     File file;
+    bool active;
     bool initialized;
     String filename;
     uint32_t loggedCount;
 
+    bool openFile();
     void writeHeader();
     String generateFilename();
     static String escapeCSV(const String& value);


### PR DESCRIPTION
## Summary
- **GPS status display (#43):** Shows GPS source (Grove/LoRa), fix status (FIX/NO FIX in green/red), and satellite count on the wardriving screen next to `WD:ON`
- **Empty WiGLE file fix (#42):** Defers CSV file creation until the first valid GPS fix, so no empty header-only files are written to SD card
- Simplified `toggleWardriving()` since file creation is now lazy

## Test plan
- [ ] Enable wardriving without GPS connected — verify no CSV file is created on SD card
- [ ] Enable wardriving with GPS connected — verify screen shows `GPS:Grove FIX SAT:X` in green
- [ ] Enable wardriving without GPS fix — verify screen shows `GPS:Grove NO FIX SAT:0` in red
- [ ] Switch GPS source with DEL — verify display updates to show `GPS:LoRa`
- [ ] Scan BLE devices with valid GPS — verify CSV file is created and contains data rows
- [ ] Toggle wardriving off/on multiple times without GPS — verify no orphan files on SD card

Closes #42, closes #43