### PR TITLE
Add interactive speech bubble system for NibBLEs

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -26,6 +26,7 @@
 #include "src/logToSerialAndWeb/logger.h"
 #include "src/gps/GPSManager.h"
 #include "src/wardriving/WigleLogger.h"
+#include "src/helper/nibblesSpeech.h"
 
 #include <WiFi.h>
 #include <AsyncTCP.h>
@@ -145,6 +146,8 @@ void setup() {
 
   ws.textAll("BLE_SCAN_READY");
 
+  nibblesSpeechBegin();
+
   startTimeDevice = millis();
   scanIsRunning = false;
 
@@ -204,10 +207,14 @@ void loop() {
     gpsManager.update();
   }
 
+  // NibBLEs speech system (idle mumbling)
+  nibblesSpeechUpdate(currentTime);
+
   // BLE scan loop
   if (bleScanEnabledWeb) {
     if (currentTime - lastFaceUpdate > FACE_UPDATE_INTERVAL_MS) {
       if (!targetFound && !scanIsRunning) {
+        nibblesSpeechNotifyEvent();
         scanForDevices();
       } else {
         targetFound = false;
@@ -241,8 +248,9 @@ void onLongPress() {
     ws.textAll("BLE_SCAN_ON");
     drawOverlay(nibblesFront, NIBBLESFRONT_WIDTH, NIBBLESFRONT_HEIGHT, 5, 0);
     drawOverlay(nibblesThugLife, NIBBLESTHUGLIFE_WIDTH, NIBBLESTHUGLIFE_HEIGHT, 80, 52);
-    showFindingCounter(targetConnects, susDevice, allSpottedDevice); 
-  } 
+    showFindingCounter(targetConnects, susDevice, allSpottedDevice);
+    nibblesSpeechShow(SpeechContext::SCAN_START);
+  }
   else {
     logToSerialAndWeb("⏹️ BLE Scan DISABLED");
     ws.textAll("BLE_SCAN_OFF");
@@ -335,6 +343,9 @@ void toggleWardriving() {
   drawOverlay(nibblesFront, NIBBLESFRONT_WIDTH, NIBBLESFRONT_HEIGHT, 5, 0);
   drawOverlay(nibblesHappy, NIBBLESHAPPY_WIDTH, NIBBLESHAPPY_HEIGHT, 83, 60);
   showFindingCounter(targetConnects, susDevice, allSpottedDevice);
+  if (wardrivingEnabled) {
+    nibblesSpeechShow(SpeechContext::WARDRIVING);
+  }
 }
 
 void switchGPSSource() {

--- a/src/helper/nibblesSpeech.cpp
+++ b/src/helper/nibblesSpeech.cpp
@@ -1,0 +1,206 @@
+#include "nibblesSpeech.h"
+#include <M5Cardputer.h>
+#include <M5Unified.h>
+#include "drawOverlay.h"
+#include "../globals/globals.h"
+#include "../images/nibblesBubble.h"
+#include "../images/nibblesFront.h"
+#include "../images/nibblesHappy.h"
+
+// --- Message pools ---
+
+static const char* idleMessages[] = {
+    "Hmm...",
+    "Anyone here?",
+    "Still scanning",
+    "Listening...",
+    "Where is everyone",
+    "So quiet...",
+    "Zzz...",
+    "Hello?",
+    "*yawn*",
+    "Bored..."
+};
+static const int idleMessageCount = sizeof(idleMessages) / sizeof(idleMessages[0]);
+
+static const char* scanStartMessages[] = {
+    "Lets go!",
+    "Start scanning!",
+    "Ready?",
+    "Lets begin!",
+    "Eyes open!",
+    "Here we go!"
+};
+static const int scanStartMessageCount = sizeof(scanStartMessages) / sizeof(scanStartMessages[0]);
+
+static const char* wardrivingMessages[] = {
+    "Lets walk!",
+    "BLE hunting!",
+    "Lets explore!",
+    "On the move!",
+    "Scanning area",
+    "Adventure time!"
+};
+static const int wardrivingMessageCount = sizeof(wardrivingMessages) / sizeof(wardrivingMessages[0]);
+
+static const char* suspiciousMessages[] = {
+    "$&%#!",
+    "Thats weird...",
+    "Suspicious...",
+    "What is that?!",
+    "Hmmmm...",
+    "Watch out!",
+    "Alert!"
+};
+static const int suspiciousMessageCount = sizeof(suspiciousMessages) / sizeof(suspiciousMessages[0]);
+
+static const char* levelUpMessages[] = {
+    "Level up!",
+    "I am learning!",
+    "More signals!",
+    "Getting better!",
+    "Leveled up!",
+    "Power up!"
+};
+static const int levelUpMessageCount = sizeof(levelUpMessages) / sizeof(levelUpMessages[0]);
+
+// --- Timing ---
+
+static unsigned long lastEventTime = 0;
+static unsigned long lastSpeechTime = 0;
+
+static const unsigned long IDLE_TIMEOUT_MS = 15000;     // 15 seconds before idle speech
+static const unsigned long SPEECH_COOLDOWN_MS = 10000;   // 10 seconds between any speech
+static const unsigned long THOUGHT_DISPLAY_MS = 3000;    // 3 seconds display time
+
+static bool thoughtVisible = false;
+static unsigned long thoughtShownAt = 0;
+
+// --- Helpers ---
+
+static const char* pickRandom(const char** pool, int count) {
+    return pool[random(0, count)];
+}
+
+void nibblesSpeechBegin() {
+    unsigned long now = millis();
+    lastEventTime = now;
+    lastSpeechTime = 0;
+    randomSeed(analogRead(0) ^ millis());
+}
+
+void drawThoughtBubble(const char* message, int x0, int y0) {
+    int textLen = strlen(message);
+    // Bubble width adapts to text (min 60, max 108 to fit screen)
+    int bubbleW = min(108, max(60, textLen * 6 + 16));
+    int bubbleH = 22;
+
+    // Draw rounded rect bubble with green theme
+    M5.Lcd.fillRoundRect(x0, y0, bubbleW, bubbleH, 4, 0x2444);  // dark green fill
+    M5.Lcd.drawRoundRect(x0, y0, bubbleW, bubbleH, 4, 0x07E0);  // green border
+
+    // Small triangle pointer toward NibBLEs (bottom-left)
+    int triX = x0 + 8;
+    int triY = y0 + bubbleH;
+    M5.Lcd.fillTriangle(triX, triY - 1, triX + 6, triY - 1, triX, triY + 4, 0x2444);
+    M5.Lcd.drawLine(triX, triY - 1, triX, triY + 4, 0x07E0);
+    M5.Lcd.drawLine(triX, triY + 4, triX + 6, triY - 1, 0x07E0);
+
+    // Draw text
+    M5.Lcd.setTextColor(0x07E0);  // green text
+    M5.Lcd.setTextSize(1);
+    M5.Lcd.setCursor(x0 + 6, y0 + 7);
+    M5.Lcd.print(message);
+}
+
+static void clearThoughtBubble() {
+    // Redraw the character area to clear the bubble region
+    drawOverlay(nibblesFront, NIBBLESFRONT_WIDTH, NIBBLESFRONT_HEIGHT, 5, 0);
+    drawOverlay(nibblesHappy, NIBBLESHAPPY_WIDTH, NIBBLESHAPPY_HEIGHT, 83, 60);
+    showFindingCounter(targetConnects, susDevice, allSpottedDevice);
+}
+
+static void showMumble(const char* message) {
+    // Clear any previous bubble area first
+    // The bubble sits at top-right area above the character
+    M5.Lcd.fillRect(125, 15, 112, 45, BLACK);
+
+    drawThoughtBubble(message, 125, 18);
+    thoughtVisible = true;
+    thoughtShownAt = millis();
+    lastSpeechTime = millis();
+}
+
+void nibblesSpeechNotifyEvent() {
+    lastEventTime = millis();
+
+    // If a thought bubble is showing, clear it when a real event happens
+    if (thoughtVisible) {
+        thoughtVisible = false;
+        clearThoughtBubble();
+    }
+}
+
+void nibblesSpeechUpdate(unsigned long currentTime) {
+    // Auto-clear thought bubble after display time
+    if (thoughtVisible && (currentTime - thoughtShownAt >= THOUGHT_DISPLAY_MS)) {
+        thoughtVisible = false;
+        clearThoughtBubble();
+        return;
+    }
+
+    // Don't show new speech if an animation task is running
+    if (isGlassesTaskRunning || isAngryTaskRunning || isSadTaskRunning) {
+        return;
+    }
+
+    // Don't show if a thought is already visible
+    if (thoughtVisible) return;
+
+    // Check cooldown
+    if (lastSpeechTime > 0 && (currentTime - lastSpeechTime < SPEECH_COOLDOWN_MS)) {
+        return;
+    }
+
+    // Check if idle long enough
+    if (currentTime - lastEventTime >= IDLE_TIMEOUT_MS) {
+        const char* msg = pickRandom(idleMessages, idleMessageCount);
+        showMumble(msg);
+        // Reset idle timer so next idle speech waits again
+        lastEventTime = currentTime;
+    }
+}
+
+void nibblesSpeechShow(SpeechContext context) {
+    unsigned long now = millis();
+
+    // Check cooldown
+    if (lastSpeechTime > 0 && (now - lastSpeechTime < SPEECH_COOLDOWN_MS)) {
+        return;
+    }
+
+    const char* msg = nullptr;
+
+    switch (context) {
+        case SpeechContext::SCAN_START:
+            msg = pickRandom(scanStartMessages, scanStartMessageCount);
+            break;
+        case SpeechContext::WARDRIVING:
+            msg = pickRandom(wardrivingMessages, wardrivingMessageCount);
+            break;
+        case SpeechContext::SUSPICIOUS:
+            msg = pickRandom(suspiciousMessages, suspiciousMessageCount);
+            break;
+        case SpeechContext::LEVEL_UP:
+            msg = pickRandom(levelUpMessages, levelUpMessageCount);
+            break;
+        case SpeechContext::IDLE:
+            msg = pickRandom(idleMessages, idleMessageCount);
+            break;
+    }
+
+    if (msg) {
+        showMumble(msg);
+        lastEventTime = now;
+    }
+}

--- a/src/helper/nibblesSpeech.h
+++ b/src/helper/nibblesSpeech.h
@@ -1,0 +1,30 @@
+#ifndef NIBBLES_SPEECH_H
+#define NIBBLES_SPEECH_H
+
+#include <Arduino.h>
+
+// Speech context categories
+enum class SpeechContext {
+    IDLE,
+    SCAN_START,
+    WARDRIVING,
+    SUSPICIOUS,
+    LEVEL_UP
+};
+
+// Initialize the speech system (call in setup)
+void nibblesSpeechBegin();
+
+// Call from loop() to check if NibBLEs should mumble
+void nibblesSpeechUpdate(unsigned long currentTime);
+
+// Notify the speech system that something happened (resets idle timer)
+void nibblesSpeechNotifyEvent();
+
+// Show a context-aware speech bubble immediately (with cooldown check)
+void nibblesSpeechShow(SpeechContext context);
+
+// Draw a thought bubble (green tint) with the given message
+void drawThoughtBubble(const char* message, int x0, int y0);
+
+#endif // NIBBLES_SPEECH_H

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -19,6 +19,7 @@
 #include "../helper/BLEDecoder.h"
 #include "../gps/GPSManager.h"
 #include "../wardriving/WigleLogger.h"
+#include "../helper/nibblesSpeech.h"
 
 // Wardriving instances (defined in GhostBLE.ino)
 extern GPSManager gpsManager;
@@ -235,6 +236,7 @@ void scanForDevices() {
      Serial.println("NO DEVICES FOUND");
   } else {
     logToSerialAndWeb("📲 DEVICES FOUND: " + String(results.getCount()));
+    nibblesSpeechNotifyEvent();
 
     scanIsRunning = true;
 
@@ -444,6 +446,7 @@ void scanForDevices() {
                 targetFound = true;
                 susDevice++;
                 logToSerialAndWeb("Target Message: !!! Target detected !!!");
+                nibblesSpeechShow(SpeechContext::SUSPICIOUS);
                 vTaskDelay(pdMS_TO_TICKS(2000));
                 if (!isAngryTaskRunning) {
                   //logToSerialAndWeb("showAngryExpressionTask");


### PR DESCRIPTION
## Summary
- NibBLEs now mumbles context-aware messages using **green thought bubbles** visually distinct from the white device-name speech bubbles
- Idle speech triggers after 15s of no BLE events with random messages like "Anyone here?", "Zzz...", "So quiet..."
- Context-triggered speech: scan start ("Lets go!"), wardriving ("BLE hunting!"), suspicious devices ("$&%#!", "Watch out!")
- 10s cooldown between messages, auto-clear after 3s, clears immediately on real BLE events
- Message pools ready for: idle, scan start, wardriving, suspicious, and level-up contexts

## Visual design
- **White bubble + black text** = device names (existing behavior, unchanged)
- **Green bubble + green text** = NibBLEs mumbling/thinking (new)
- Thought bubble is drawn with LCD primitives (`fillRoundRect` + triangle pointer) so no new image asset is needed

## Test plan
- [ ] Wait 15+ seconds with no BLE devices nearby — verify green thought bubble appears with idle message
- [ ] Verify thought bubble disappears after ~3 seconds
- [ ] Enable BLE scan — verify "Lets go!" or similar scan-start message appears
- [ ] Toggle wardriving — verify wardriving message appears in green bubble
- [ ] Detect a suspicious device — verify suspicious message appears
- [ ] Verify white speech bubbles for device names still work as before
- [ ] Verify no messages appear faster than every 10 seconds (cooldown)

Closes #40