### PR TITLE
Fix device name truncation exceeding speech bubble width

### DIFF
--- a/src/helper/showExpression.cpp
+++ b/src/helper/showExpression.cpp
@@ -109,7 +109,7 @@ void showGlassesExpressionTask(void* parameter) {
 
     if (localName.length() > 0) {
       if(localName.length() > 14) {
-        localName = localName.substring(0, 15) + "...";
+        localName = localName.substring(0, 11) + "...";
       }
       M5.Lcd.fillRoundRect(125, 15, 108, 22, 4, WHITE);
       M5.Lcd.drawRoundRect(125, 15, 108, 22, 4, 0x2104);
@@ -155,7 +155,7 @@ void showSadExpressionTask(void* parameter) {
 
     if (localName.length() > 0) {
       if(localName.length() > 14) {
-        localName = localName.substring(0, 15) + "...";
+        localName = localName.substring(0, 11) + "...";
       }
       M5.Lcd.fillRoundRect(125, 15, 108, 22, 4, WHITE);
       M5.Lcd.drawRoundRect(125, 15, 108, 22, 4, 0x2104);


### PR DESCRIPTION
## Summary
- Fixed buffer overflow risk where truncated device names exceeded the speech bubble width
- The truncation logic used `substring(0, 15) + "..."` producing 18-character strings, but the 108px-wide bubble (with ~6px padding on each side) only fits ~16 characters at 6px per character
- Changed to `substring(0, 11) + "..."` = 14 characters total, matching the `> 14` length threshold that gates truncation
- Fix applied to both occurrences: `showGlassesExpressionTask` and `showSadExpressionTask`

## Test plan
- [ ] Flash firmware and verify long device names (>14 chars) display correctly within the speech bubble
- [ ] Verify short device names (<= 14 chars) still display without truncation
- [ ] Check both glasses and sad expression tasks show names properly

Fixes #74