### PR TITLE
Add String.reserve() before loop concatenations

### DIFF
--- a/src/helper/BLEDecoder.cpp
+++ b/src/helper/BLEDecoder.cpp
@@ -9,7 +9,8 @@ extern SDLogger sdLogger;
 
 static String toHex(uint8_t* data, size_t len)
 {
-    String hex = "";
+    String hex;
+    hex.reserve(len * 3);
     for (size_t i = 0; i < len; i++)
     {
         if (data[i] < 16) hex += "0";
@@ -23,7 +24,8 @@ static String toHex(uint8_t* data, size_t len)
 
 static String toASCII(uint8_t* data, size_t len)
 {
-    String ascii = "";
+    String ascii;
+    ascii.reserve(len);
 
     for (size_t i = 0; i < len; i++)
     {
@@ -95,7 +97,8 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
     if (length % 2 == 0 && length <= 16)
     {
         xpManager.awardXP(10);  // +10 XP: UINT payload decoded
-        String values = "";
+        String values;
+        values.reserve(length * 3);
 
         for (size_t i = 0; i < length; i += 2)
         {
@@ -113,7 +116,8 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
     // ---- UINT32 detection ----
     if (length % 4 == 0 && length <= 16)
     {
-        String values = "";
+        String values;
+        values.reserve(length * 3);
 
         for (size_t i = 0; i < length; i += 4)
         {

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -35,7 +35,8 @@ SDLogger sdLogger;
 // Subscribe to all notifiable characteristics on a connected device
 template<typename Callback>
 void subscribeToAllNotifications(NimBLEClient* client, Callback notifyCallback) {
-  String logSubs = "Subscribing: " ;
+  String logSubs;
+  logSubs.reserve(256);
     if (!client) return;
     auto services = client->getServices(); // returns std::vector<NimBLERemoteService*>
     for (auto* service : services) {
@@ -181,6 +182,7 @@ bool isPrintableText(const std::string& s)
 String bytesToHexString(const std::string& data)
 {
     String out;
+    out.reserve(data.length() * 3);
 
     for (uint8_t b : data)
     {


### PR DESCRIPTION
## Summary
- Pre-allocate `String` capacity with `.reserve()` before loops that build strings via `+=`
- Reduces repeated heap reallocations on ESP32, lowering fragmentation risk
- Applied to `bytesToHexString()`, `subscribeToAllNotifications()`, `toHex()`, `toASCII()`, and UINT16/UINT32 decode blocks

## Test plan
- [ ] Verify BLE scan output still shows correct hex strings
- [ ] Verify notification subscription logging works
- [ ] Monitor free heap during extended scanning sessions

Fixes #51