### PR TITLE
Move seenDevices limits to config.h, reduce max to 200

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -220,7 +220,7 @@ void loop() {
   // Timer every 60 minutes
   unsigned long currentTimeDevice = millis();
   if (currentTimeDevice - startTimeDevice >= timerDurationDevice) {
-    Serial.println("60 Minuten sind vorbei!");
+    Serial.println("Timer: periodic seenDevices reset");
     if (!seenDevices.empty()) {
       // Swap with empty set to free memory instantly via pointer swap,
       // avoiding per-node deallocation blocking the main loop
@@ -229,7 +229,6 @@ void loop() {
     } else {
       Serial.println("SEEN DEVICES STILL EMPTY");
     }
-    Serial.println("Update Batterie State");
     startTimeDevice = millis();
   }
   // Let system handle BLE, GPIO, etc.

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -47,6 +47,10 @@ extern const char* CATHACK_SERVICE_UUID_3;
 // ===== Time Intervals =====
 #define FACE_UPDATE_INTERVAL_MS 1000
 
+// ===== Seen Devices Limits =====
+#define MAX_SEEN_DEVICES 200
+#define MIN_FREE_HEAP_BYTES 20000
+
 // ===== Constants =====
 #define RSSI_CONSTANT 20
 #define DISTANCE_CONSTANT -69

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -90,8 +90,7 @@ void genericNotifyCallback(NimBLERemoteCharacteristic* pChar,
 
 bool isTarget = false;
 
-#define MAX_SEEN_DEVICES 500
-#define MIN_FREE_HEAP_BYTES 20000
+// MAX_SEEN_DEVICES and MIN_FREE_HEAP_BYTES defined in config.h
 
 struct IBeaconInfo {
   bool valid = false;


### PR DESCRIPTION
## Summary
- Move `MAX_SEEN_DEVICES` and `MIN_FREE_HEAP_BYTES` from `ScanDevices.cpp` to `config.h` for centralized configuration
- Reduce `MAX_SEEN_DEVICES` from 500 to 200 to lower peak memory usage on ESP32
- Use swap-with-empty pattern in timer reset for immediate memory release

## Test plan
- [ ] Verify devices are still properly deduplicated during scanning
- [ ] Monitor heap usage with `ESP.getFreeHeap()` during extended sessions
- [ ] Confirm timer-based reset still works after 30 minutes

Fixes #50