### PR TITLE
Reuse pre-allocated String for nameList logging loop

### DIFF
--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -470,9 +470,13 @@ void scanForDevices() {
             logToSerialAndWeb(String("   Name:    " + localName));
             logToSerialAndWeb(String("   Manuf.:  " + manufacturerName));
             logToSerialAndWeb("   Device Name: ");
+            String logLine;
+            logLine.reserve(64);
             for (const auto& names : nameList) {
               if (!names.empty()) {
-                logToSerialAndWeb(String("     - ") + names.c_str());
+                logLine = "     - ";
+                logLine += names.c_str();
+                logToSerialAndWeb(logLine);
               }
             }
 


### PR DESCRIPTION
## Summary
- Replace per-iteration `String` creation in the nameList logging loop with a single pre-allocated `String` that is reused
- Reduces temporary heap allocations during device info logging

## Test plan
- [ ] Verify device name list still logs correctly during scan
- [ ] Monitor heap usage during scan with multiple named devices

Fixes #52