### PR TITLE
Add mutex to prevent duplicate expression task creation

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -102,6 +102,7 @@ void setup() {
   Serial.println("GhostBLE starting...");
 
   initLogger();
+  taskMutex = xSemaphoreCreateMutex();
 
   #if defined(CARDPUTER)
   M5.Lcd.setRotation(1);

--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -22,6 +22,7 @@ std::atomic<bool> isThugLifeTaskRunning{false};
 TaskHandle_t glassesTaskHandle = NULL;
 TaskHandle_t angryTaskHandle = NULL;
 TaskHandle_t sadTaskHandle = NULL;
+SemaphoreHandle_t taskMutex = NULL;
 
 bool isWebLogActive = false;
 bool is_connectable = false;

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -28,6 +28,7 @@ extern std::atomic<bool> isThugLifeTaskRunning;
 extern TaskHandle_t glassesTaskHandle;
 extern TaskHandle_t angryTaskHandle;
 extern TaskHandle_t sadTaskHandle;
+extern SemaphoreHandle_t taskMutex;
 extern bool isWebLogActive;
 extern bool is_connectable;
 extern bool bleScanEnabledWeb;

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -308,8 +308,12 @@ static bool connectAndReadGATT(
   targetConnects++;
   xpManager.awardXP(5);  // +5 XP: GATT connection success
 
-  if (!isGlassesTaskRunning && !isAngryTaskRunning) {
-    xTaskCreatePinnedToCore(showGlassesExpressionTask, "BLEGlasses", 4096, NULL, 0, &glassesTaskHandle, 1);
+  if (xSemaphoreTake(taskMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    if (!isGlassesTaskRunning && !isAngryTaskRunning) {
+      isGlassesTaskRunning = true;
+      xTaskCreatePinnedToCore(showGlassesExpressionTask, "BLEGlasses", 4096, NULL, 0, &glassesTaskHandle, 1);
+    }
+    xSemaphoreGive(taskMutex);
   }
 
   // Subscribe to notifications for all characteristics that support it
@@ -373,9 +377,12 @@ static bool connectAndReadGATT(
       logToSerialAndWeb("Target Message: !!! Target detected !!!");
       nibblesSpeechShow(SpeechContext::SUSPICIOUS);
       vTaskDelay(pdMS_TO_TICKS(2000));
-      if (!isAngryTaskRunning) {
-        //logToSerialAndWeb("showAngryExpressionTask");
-        xTaskCreatePinnedToCore(showAngryExpressionTask, "AngryFace", 4096, NULL, 4, &angryTaskHandle, 1);
+      if (xSemaphoreTake(taskMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        if (!isAngryTaskRunning) {
+          isAngryTaskRunning = true;
+          xTaskCreatePinnedToCore(showAngryExpressionTask, "AngryFace", 4096, NULL, 4, &angryTaskHandle, 1);
+        }
+        xSemaphoreGive(taskMutex);
       }
       isTarget = true;
       return true;  // target found — caller should break
@@ -600,9 +607,12 @@ void scanForDevices() {
 
             ExposureResult exposure = analyzeExposure(dev);
 
-            if (!isGlassesTaskRunning && !isAngryTaskRunning && !isSadTaskRunning) {
-              //logToSerialAndWeb("showSadExpressionTask");
-              xTaskCreatePinnedToCore(showSadExpressionTask, "SadFace", 4096, NULL, 1, &sadTaskHandle, 1);
+            if (xSemaphoreTake(taskMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+              if (!isGlassesTaskRunning && !isAngryTaskRunning && !isSadTaskRunning) {
+                isSadTaskRunning = true;
+                xTaskCreatePinnedToCore(showSadExpressionTask, "SadFace", 4096, NULL, 1, &sadTaskHandle, 1);
+              }
+              xSemaphoreGive(taskMutex);
             }
 
             // Only write to SD if device has a name


### PR DESCRIPTION
## Summary
- Add `taskMutex` to protect expression task creation from race conditions
- Wrap all three task creation sites (glasses, angry, sad) with mutex acquire/release
- Set the `isXxxTaskRunning` flag under the mutex *before* `xTaskCreatePinnedToCore` to prevent duplicate tasks on dual-core ESP32

## Test plan
- [ ] Verify expression animations still trigger on device connection / suspicious device detection
- [ ] Verify no duplicate tasks are created under rapid scanning
- [ ] Monitor free heap and task count during extended sessions

Fixes #53