### PR TITLE
Increase logger mutex timeout and add write-readiness checks

### DIFF
--- a/src/logToSerialAndWeb/logger.cpp
+++ b/src/logToSerialAndWeb/logger.cpp
@@ -8,14 +8,16 @@ void initLogger() {
 }
 
 void logToSerialAndWeb(const String& msg) {
-  if (logMutex != NULL && xSemaphoreTake(logMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-    Serial.println(msg);
-    if (ws.count() > 0) {
+  if (logMutex != NULL && xSemaphoreTake(logMutex, pdMS_TO_TICKS(500)) == pdTRUE) {
+    if (Serial.availableForWrite() > 0) {
+      Serial.println(msg);
+    }
+    if (ws.count() > 0 && ws.availableForWriteAll()) {
       ws.textAll(msg);
     }
     xSemaphoreGive(logMutex);
   } else {
-    // Fallback: at least write to serial if mutex unavailable
+    // Fallback: write to serial without mutex if timeout exceeded
     Serial.println(msg);
   }
 }


### PR DESCRIPTION
## Summary
- Increase mutex timeout from 100ms to 500ms to reduce contention-related fallback path usage
- Check `Serial.availableForWrite()` before writing to avoid blocking on a full serial buffer
- Check `ws.availableForWriteAll()` before WebSocket send to avoid blocking when clients are slow

## Test plan
- [ ] Verify serial and WebSocket logging still works
- [ ] Monitor for watchdog resets during heavy scanning

Fixes #54