### PR TITLE
Remove extern SDLogger in favor of parameter passing

### DIFF
--- a/src/helper/BLEDecoder.cpp
+++ b/src/helper/BLEDecoder.cpp
@@ -4,9 +4,6 @@
 #include "../globals/globals.h"
 #include <string>
 
-// Forward declarations of required services/classes
-extern SDLogger sdLogger;
-
 static String toHex(uint8_t* data, size_t len)
 {
     String hex;
@@ -38,7 +35,7 @@ static String toASCII(uint8_t* data, size_t len)
     return ascii;
 }
 
-void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
+void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length, SDLogger& sdLogger)
 {
     String uuidStr = String(uuid.c_str());
 

--- a/src/helper/BLEDecoder.h
+++ b/src/helper/BLEDecoder.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Arduino.h>
-#include <string> 
+#include <string>
 
-void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length);
+class SDLogger;
+
+void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length, SDLogger& sdLogger);

--- a/src/privacyCheck/devicePrivacy.cpp
+++ b/src/privacyCheck/devicePrivacy.cpp
@@ -1,8 +1,5 @@
 #include "devicePrivacy.h"
 #include "../globals/globals.h"
-#include "../sdCard/SDLogger.h"
-
-extern SDLogger sdLogger; // -> not nice impl, but for logging in this file we need access to the SDLogger instance
 
 #include <map>
 #include <vector>

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -28,8 +28,6 @@ extern WigleLogger wigleLogger;
 
 NimBLEClient *pClient = nullptr;
 
-// Forward declarations of required services/classes
-class SDLogger;
 SDLogger sdLogger;
 
 // Subscribe to all notifiable characteristics on a connected device
@@ -87,7 +85,7 @@ void genericNotifyCallback(NimBLERemoteCharacteristic* pChar,
     NimBLEUUID charUUID = pChar->getUUID();
 
     // Forward everything to the decoder
-    decodeBLEData(charUUID.toString(), data, length);
+    decodeBLEData(charUUID.toString(), data, length, sdLogger);
 }
 
 bool isTarget = false;


### PR DESCRIPTION
## Summary
- Removed unused `extern SDLogger sdLogger` from `devicePrivacy.cpp` (the variable was declared but never referenced in that file)
- Replaced `extern SDLogger sdLogger` in `BLEDecoder.cpp` with an explicit `SDLogger&` parameter on `decodeBLEData()`
- Updated the call site in `ScanDevices.cpp` to pass `sdLogger` directly
- Removed the redundant `class SDLogger;` forward declaration in `ScanDevices.cpp` (already included via header)

`sdLogger` remains defined as a global in `ScanDevices.cpp` where it is owned, but other modules now receive it through function parameters instead of reaching for it via `extern`.

Closes #59

## Test plan
- [ ] Verify the project compiles without errors on the M5Cardputer target
- [ ] Confirm BLE notify data is still logged to SD card (exercises the updated `decodeBLEData` path)
- [ ] Confirm privacy analysis still works end-to-end (exercises the cleaned-up `devicePrivacy.cpp`)