### PR TITLE
Make global counters atomic for thread safety

### DIFF
--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -30,14 +30,14 @@ bool is_connectable = false;
 bool bleScanEnabledWeb = false;
 bool wardrivingEnabled = false;
 
-int susDevice = 0;
-int beaconsFound = 0;
-int targetConnects = 0;
-int allSpottedDevice = 0;
-int leakedCounter = 0;
-int batteryPercent = 0;
-int riskScore = 0;
-int rssi = 0;
+std::atomic<int> susDevice{0};
+std::atomic<int> beaconsFound{0};
+std::atomic<int> targetConnects{0};
+std::atomic<int> allSpottedDevice{0};
+std::atomic<int> leakedCounter{0};
+std::atomic<int> batteryPercent{0};
+std::atomic<int> riskScore{0};
+std::atomic<int> rssi{0};
 
 unsigned long lastScanTime = 0;
 unsigned long lastFaceUpdate = 0;

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -38,14 +38,14 @@ extern bool is_connectable;
 extern bool bleScanEnabledWeb;
 extern bool wardrivingEnabled;
 
-extern int susDevice;
-extern int beaconsFound;
-extern int targetConnects;
-extern int allSpottedDevice;
-extern int leakedCounter;
-extern int batteryPercent;
-extern int riskScore;
-extern int rssi;
+extern std::atomic<int> susDevice;
+extern std::atomic<int> beaconsFound;
+extern std::atomic<int> targetConnects;
+extern std::atomic<int> allSpottedDevice;
+extern std::atomic<int> leakedCounter;
+extern std::atomic<int> batteryPercent;
+extern std::atomic<int> riskScore;
+extern std::atomic<int> rssi;
 
 extern unsigned long lastScanTime;
 extern unsigned long lastFaceUpdate;


### PR DESCRIPTION
## Summary
- Change 8 global counters from `int` to `std::atomic<int>` to prevent data races on dual-core ESP32
- Affected: `susDevice`, `beaconsFound`, `targetConnects`, `allSpottedDevice`, `leakedCounter`, `batteryPercent`, `riskScore`, `rssi`
- All existing `++`, `+=`, `-=`, and pass-by-value operations work correctly with `std::atomic<int>`

## Test plan
- [ ] Verify counters still display correctly in the UI
- [ ] Verify scan statistics are accurate during extended sessions
- [ ] No compile errors with atomic types

Fixes #60