### PR TITLE
Remove unused global variables hasManuData and skipLogging

### DIFF
--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -13,8 +13,6 @@ std::vector<std::string> nameList;
 bool scanIsRunning = false;
 
 bool targetFound = false;
-bool hasManuData = false;
-bool skipLogging = false;
 std::atomic<bool> isGlassesTaskRunning{false};
 std::atomic<bool> isAngryTaskRunning{false};
 std::atomic<bool> isSadTaskRunning{false};

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -21,8 +21,6 @@ extern bool scanIsRunning;
 
 // Global flags and strings
 extern bool targetFound;
-extern bool hasManuData;
-extern bool skipLogging;
 extern std::atomic<bool> isGlassesTaskRunning;
 extern std::atomic<bool> isAngryTaskRunning;
 extern std::atomic<bool> isSadTaskRunning;


### PR DESCRIPTION
## Summary
- Removes `hasManuData` and `skipLogging` from `globals.h` (declarations) and `globals.cpp` (definitions)
- Both variables were declared and defined but never read or written anywhere in the codebase

Fixes #65