### PR TITLE
Remove unused #include <map> in ScanDevices.cpp

### DIFF
--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -1,7 +1,6 @@
 #include <NimBLEDevice.h>
 #include <M5Cardputer.h>
 #include <set>
-#include <map>
 #include <vector>
 #include <algorithm>
 


### PR DESCRIPTION
## Summary
- Removes the unused `#include <map>` from `src/scanner/ScanDevices.cpp`
- `std::map` is not referenced anywhere in the file

Closes #67