### PR TITLE
Fix duplicate include in devicePrivacy.cpp

### DIFF
--- a/src/privacyCheck/devicePrivacy.cpp
+++ b/src/privacyCheck/devicePrivacy.cpp
@@ -97,8 +97,6 @@ bool isLikelyCleartextBytes(const std::vector<uint8_t>& bytes, size_t minLength)
   return printableCount >= minLength;
 }
 
-#include "devicePrivacy.h"
-
 bool isUniversallyAdministeredMAC(const std::string& mac)
 {
     if (mac.length() < 2)


### PR DESCRIPTION
## Summary
- Removes the duplicate `#include "devicePrivacy.h"` that appeared at line 100, after implementation code
- The header was already correctly included at line 1 of the file

Fixes #71