### PR TITLE
Fix redundant double canNotify() check in subscribeToAllNotifications

### DIFF
--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -44,31 +44,30 @@ void subscribeToAllNotifications(NimBLEClient* client, Callback notifyCallback) 
         auto characteristics = service->getCharacteristics(true); // returns std::vector<NimBLERemoteCharacteristic*>
         for (auto* characteristic : characteristics) {
           if (!characteristic) continue;
-          if (characteristic->canNotify()) 
-          {
-            if (characteristic->canNotify()) {
-                characteristic->subscribe(true, notifyCallback);
-                xpManager.awardXP(10);  // +10 XP: characteristic subscription
-            } else if (characteristic->canIndicate()) {
-                characteristic->subscribe(false, notifyCallback);
-                xpManager.awardXP(10);  // +10 XP: characteristic subscription
-            }
-            if (characteristic->canRead()) {
-                std::string val = characteristic->readValue();
-                logToSerialAndWeb(("   Read value length: " + String(val.length())).c_str());
-                logSubs += "   Read value length: " + String(val.length());
-            }
-            logToSerialAndWeb(
-                String("   Subscribed to notifis for char ") +
-                characteristic->getUUID().toString().c_str() +
-                " in service " +
-                service->getUUID().toString().c_str()
-            );
-            logSubs += String("   Subscribed to notifis for char ") + 
-                characteristic->getUUID().toString().c_str() +
-                " in service " +
-                service->getUUID().toString().c_str();
+          if (characteristic->canNotify()) {
+              characteristic->subscribe(true, notifyCallback);
+              xpManager.awardXP(10);  // +10 XP: characteristic subscription
+          } else if (characteristic->canIndicate()) {
+              characteristic->subscribe(false, notifyCallback);
+              xpManager.awardXP(10);  // +10 XP: characteristic subscription
+          } else {
+              continue;
           }
+          if (characteristic->canRead()) {
+              std::string val = characteristic->readValue();
+              logToSerialAndWeb(("   Read value length: " + String(val.length())).c_str());
+              logSubs += "   Read value length: " + String(val.length());
+          }
+          logToSerialAndWeb(
+              String("   Subscribed to notifis for char ") +
+              characteristic->getUUID().toString().c_str() +
+              " in service " +
+              service->getUUID().toString().c_str()
+          );
+          logSubs += String("   Subscribed to notifis for char ") +
+              characteristic->getUUID().toString().c_str() +
+              " in service " +
+              service->getUUID().toString().c_str();
           if (logSubs.length() > 0) {
             sdLogger.writeCategory(logSubs);
           }


### PR DESCRIPTION
## Summary

- Removes the redundant nested canNotify() check inside subscribeToAllNotifications() that made the else if (canIndicate()) branch unreachable dead code
- Flattens the logic into a single if/else if/else continue block so both canNotify() and canIndicate() paths are reachable
- Keeps all subsequent logic (canRead, logging, SD writes) at the correct indentation and scope

Fixes #66