### PR TITLE
Fix redundant null checks and inconsistent error handling

### DIFF
--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -216,26 +216,16 @@ void scanForDevices() {
 
   if (pScan == nullptr) {
     Serial.println("Scan instance creation failed.");
-    return;  // Early exit if pScan is null
+    return;
   }
 
-  if (pScan != nullptr) {
-    pScan->clearResults();        // 1. Clear previous results first
-    pScan->setActiveScan(true);   // 2. Set active scan mode
-    pScan->setInterval(45);       // 3. Set scan interval // old 1000
-    pScan->setWindow(15);         // 4. Set scan window   // old 900
-    delay(100);                   // Optional small delay for stability
-  } else {
-    Serial.println("⚠️ pScan is null!");
-  }
+  pScan->clearResults();        // 1. Clear previous results first
+  pScan->setActiveScan(true);   // 2. Set active scan mode
+  pScan->setInterval(45);       // 3. Set scan interval // old 1000
+  pScan->setWindow(15);         // 4. Set scan window   // old 900
+  delay(100);                   // Optional small delay for stability
 
-  NimBLEScanResults results;
-
-  if (pScan != nullptr) {
-    results = pScan->getResults(3000);  // Scan 3 seconds to get scan results -> maybe check 3sec for smaller list and earlier new scan
-  } else {
-    Serial.println("⚠️ pScan is null! Cannot get scan results.");
-  }
+  NimBLEScanResults results = pScan->getResults(3000);  // Scan 3 seconds to get scan results -> maybe check 3sec for smaller list and earlier new scan
   
   if (results.getCount() == 0) {
      Serial.println("NO DEVICES FOUND");
@@ -417,33 +407,26 @@ void scanForDevices() {
                     hasWritableChar = true;
                 }
                                 
-                if (characteristic)
-                {
-                    std::string rawValue = characteristic->readValue();
+                std::string rawValue = characteristic->readValue();
 
-                    if (!rawValue.empty())
+                if (!rawValue.empty())
+                {
+                    if (isPrintableText(rawValue))
                     {
-                        if (isPrintableText(rawValue))
+                        dev.gattHasName = true;   // ← missing in many cases
+                        nameList.push_back(rawValue);
+
+                        if (looksLikePersonalName(rawValue))
                         {
-                            dev.gattHasName = true;   // ← missing in many cases
-                            nameList.push_back(rawValue);
-
-                            if (looksLikePersonalName(rawValue))
-                            {
-                                dev.gattHasPersonalName = true;
-                            }
-
-                            if (looksLikeIdentityData(rawValue))
-                                dev.gattHasIdentityInfo = true;
-
-                            if (looksLikeEnvironmentName(rawValue))
-                                dev.gattHasEnvironmentName = true;
+                            dev.gattHasPersonalName = true;
                         }
+
+                        if (looksLikeIdentityData(rawValue))
+                            dev.gattHasIdentityInfo = true;
+
+                        if (looksLikeEnvironmentName(rawValue))
+                            dev.gattHasEnvironmentName = true;
                     }
-                }
-                else
-                {
-                    Serial.println("   Device Name Characteristic not found.");
                 }
               }
 


### PR DESCRIPTION
## Summary
- Converted redundant `pScan` null checks into a single early-return guard clause, removing two dead `else` branches that could never execute
- Removed unreachable `characteristic` null check where the pointer was already dereferenced by `canWrite()`/`canWriteNoResponse()` calls above it, along with the dead `else` branch

## Test plan
- [ ] Verify BLE scanning still works correctly on device
- [ ] Confirm no regression in device discovery or characteristic reading

Fixes #73