### PR TITLE
Standardize header guards to #pragma once

### DIFF
--- a/src/GATTServices/batteryLevelService.h
+++ b/src/GATTServices/batteryLevelService.h
@@ -1,5 +1,4 @@
-#ifndef BATTERY_LEVEL_SERVICE_H
-#define BATTERY_LEVEL_SERVICE_H
+#pragma once
 
 #include <NimBLEClient.h>
 #include <Arduino.h>
@@ -9,5 +8,3 @@ public:
     // Reads battery level from connected client (0x180F service)
     static String readBatteryLevel(NimBLEClient* pClient);
 };
-
-#endif // BATTERY_LEVEL_SERVICE_H

--- a/src/GATTServices/deviceInfoService.h
+++ b/src/GATTServices/deviceInfoService.h
@@ -1,5 +1,4 @@
-#ifndef DEVICE_INFO_SERVICE_H
-#define DEVICE_INFO_SERVICE_H
+#pragma once
 
 #include <Arduino.h>
 #include <NimBLEDevice.h>
@@ -8,5 +7,3 @@ class DeviceInfoServiceHandler {
 public:
     static String readDeviceInfo(NimBLEClient* pClient);  // Pass the connected client
 };
-
-#endif // DEVICE_INFO_SERVICE_H

--- a/src/GATTServices/genericAccessService.h
+++ b/src/GATTServices/genericAccessService.h
@@ -1,5 +1,4 @@
-#ifndef GENERIC_ACCESS_SERVICE_H
-#define GENERIC_ACCESS_SERVICE_H
+#pragma once
 
 #include <NimBLEClient.h>
 #include <Arduino.h>
@@ -8,5 +7,3 @@ class GenericAccessServiceHandler {
 public:
     static String readGenericAccessInfo(NimBLEClient* pClient);
 };
-
-#endif

--- a/src/GATTServices/heartRateService.h
+++ b/src/GATTServices/heartRateService.h
@@ -1,5 +1,4 @@
-#ifndef HEART_RATE_SERVICE_H
-#define HEART_RATE_SERVICE_H
+#pragma once
 
 #include <NimBLEClient.h>
 #include <Arduino.h>
@@ -8,5 +7,3 @@ class HeartRateServiceHandler {
 public:
   static String readHeartRate(NimBLEClient* pClient);
 };
-
-#endif

--- a/src/GATTServices/temperatureService.h
+++ b/src/GATTServices/temperatureService.h
@@ -1,5 +1,4 @@
-#ifndef TEMP_SERVICE_H
-#define TEMP_SERVICE_H
+#pragma once
 
 #include <Arduino.h>
 #include <NimBLEClient.h>
@@ -8,5 +7,3 @@ class TemperatureServiceHandler {
 public:
     static String readTemperature(NimBLEClient* pClient);
 };
-
-#endif

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -1,5 +1,4 @@
-#ifndef CONFIG_H
-#define CONFIG_H
+#pragma once
 
 #include <Arduino.h>
 
@@ -51,5 +50,3 @@ extern const char* CATHACK_SERVICE_UUID_3;
 // ===== Constants =====
 #define RSSI_CONSTANT 20
 #define DISTANCE_CONSTANT -69
-
-#endif // CONFIG_H

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -1,6 +1,3 @@
-#ifndef GLOBALS_H
-#define GLOBALS_H
-
 #pragma once
 #include <set>
 #include <string>
@@ -68,6 +65,3 @@ extern String timeInfoService;
 extern String lastConnectedDeviceInfo;
 
 extern const char index_html[] PROGMEM;
-
-
-#endif // GLOBALS_H

--- a/src/helper/ManufacturerHelper.h
+++ b/src/helper/ManufacturerHelper.h
@@ -1,8 +1,5 @@
-#ifndef MANUFACTURER_HELPER_H
-#define MANUFACTURER_HELPER_H
+#pragma once
 
 #include <Arduino.h>
 
 String getManufacturerName(uint16_t manufacturerId);
-
-#endif

--- a/src/helper/ServiceHelper.h
+++ b/src/helper/ServiceHelper.h
@@ -1,8 +1,5 @@
-#ifndef SERVICE_HELPER_H
-#define SERVICE_HELPER_H
+#pragma once
 
 #include <Arduino.h>
 
 String getServiceName(const String& serviceUuid);
-
-#endif

--- a/src/helper/drawOverlay.h
+++ b/src/helper/drawOverlay.h
@@ -1,5 +1,4 @@
-#ifndef DRAW_OVERLAY_H
-#define DRAW_OVERLAY_H
+#pragma once
 
 #include <M5Cardputer.h>
 
@@ -11,5 +10,3 @@
 // - x0: x-coordinate to start drawing
 // - y0: y-coordinate to start drawing
 void drawOverlay(const uint16_t* img, int w, int h, int x0, int y0);
-
-#endif // DRAW_OVERLAY_H

--- a/src/helper/nibblesSpeech.h
+++ b/src/helper/nibblesSpeech.h
@@ -1,5 +1,4 @@
-#ifndef NIBBLES_SPEECH_H
-#define NIBBLES_SPEECH_H
+#pragma once
 
 #include <Arduino.h>
 
@@ -26,5 +25,3 @@ void nibblesSpeechShow(SpeechContext context);
 
 // Draw a thought bubble (green tint) with the given message
 void drawThoughtBubble(const char* message, int x0, int y0);
-
-#endif // NIBBLES_SPEECH_H

--- a/src/helper/showExpression.h
+++ b/src/helper/showExpression.h
@@ -1,5 +1,4 @@
-#ifndef SHOW_EXPRESSION_H
-#define SHOW_EXPRESSION_H
+#pragma once
 
 #include <Arduino.h>
 
@@ -9,5 +8,3 @@ void showSadExpressionTask(void* parameter);
 void showThugLifeExpressionTask(void* parameter);
 void showHappyExpressionTask(void* parameter);
 void showFindingCounter(int sniffed, int susDevice, int spotted);
-
-#endif

--- a/src/logToSerialAndWeb/logger.h
+++ b/src/logToSerialAndWeb/logger.h
@@ -1,5 +1,4 @@
-#ifndef LOGGER_H
-#define LOGGER_H
+#pragma once
 
 #include <Arduino.h>
 #include <ESPAsyncWebServer.h>
@@ -9,5 +8,3 @@ extern SemaphoreHandle_t logMutex;
 
 void initLogger();
 void logToSerialAndWeb(const String& msg);
-
-#endif // LOGGER_H

--- a/src/privacyCheck/devicePrivacy.h
+++ b/src/privacyCheck/devicePrivacy.h
@@ -1,5 +1,4 @@
-#ifndef DEVICE_PRIVACY_H
-#define DEVICE_PRIVACY_H
+#pragma once
 
 #include <Arduino.h>
 #include <string>
@@ -48,5 +47,3 @@ String payloadToHexString(const String& payload);
 
 // Logging (defined elsewhere)
 void logToSerialAndWeb(const String& line);
-
-#endif // DEVICE_PRIVACY_H

--- a/src/scanner/ScanDevices.h
+++ b/src/scanner/ScanDevices.h
@@ -1,5 +1,4 @@
-#ifndef SCANDEVICES_H
-#define SCANDEVICES_H
+#pragma once
 
 #include <Arduino.h>
 #include "../config/config.h"
@@ -20,5 +19,3 @@ void showGlassesExpressionTask(void* parameter);
 void showAngryExpressionTask(void* parameter);
 void showSadExpressionTask(void* parameter);
 void showFindingCounter(int sniffed, int susDevice, int spotted);
-
-#endif // SCANDEVICES_H

--- a/src/target/TargetDevice.h
+++ b/src/target/TargetDevice.h
@@ -1,8 +1,5 @@
-#ifndef TARGET_DEVICE_H
-#define TARGET_DEVICE_H
+#pragma once
 
 #include <Arduino.h>
 
 bool isTargetDevice(String name, String address, String serviceUuid, String deviceInfoService);
-
-#endif  // TARGET_DEVICE_H

--- a/src/xp/XPManager.h
+++ b/src/xp/XPManager.h
@@ -1,5 +1,4 @@
-#ifndef XP_MANAGER_H
-#define XP_MANAGER_H
+#pragma once
 
 #include <Arduino.h>
 #include <SD.h>
@@ -33,5 +32,3 @@ private:
     uint32_t xpForLevel(uint16_t level);
     void recalculateLevel();
 };
-
-#endif


### PR DESCRIPTION
## Summary
- Replaces all `#ifndef`/`#define`/`#endif` include guards with `#pragma once` across 17 header files
- Cleans up `globals.h` which had both `#pragma once` and `#ifndef` guards redundantly
- Image headers (`src/images/*.h`) had no guards and were left unchanged

Fixes #70