### PR TITLE
Define BLE scan parameters and GATT UUID constants in config.h

### DIFF
--- a/src/GATTServices/genericAccessService.cpp
+++ b/src/GATTServices/genericAccessService.cpp
@@ -1,14 +1,15 @@
 #include "genericAccessService.h"
 #include <Arduino.h>
-#include <NimBLEDevice.h> 
+#include <NimBLEDevice.h>
 
+#include "../config/config.h"
 #include "../logToSerialAndWeb/logger.h"
 
 
 String GenericAccessServiceHandler::readGenericAccessInfo(NimBLEClient* pClient) {
     String accessInfoString = "";
 
-    NimBLERemoteService* gapService = pClient->getService("1800");
+    NimBLERemoteService* gapService = pClient->getService(UUID_GENERIC_ACCESS);
     if (!gapService) {
         logToSerialAndWeb("   Generic Access Service not found (0x1800)");
         return accessInfoString;

--- a/src/GATTServices/temperatureService.cpp
+++ b/src/GATTServices/temperatureService.cpp
@@ -3,6 +3,7 @@
 #include <NimBLERemoteService.h>
 #include <NimBLERemoteCharacteristic.h>
 
+#include "../config/config.h"
 #include "../globals/globals.h"
 #include "../logToSerialAndWeb/logger.h"
 
@@ -31,7 +32,7 @@ String TemperatureServiceHandler::readTemperature(NimBLEClient* pClient) {
 
     if (!pClient) return "";
 
-    NimBLERemoteService* tempService = pClient->getService("1809");
+    NimBLERemoteService* tempService = pClient->getService(UUID_HEALTH_THERMOMETER);
     if (!tempService) {
         logToSerialAndWeb("     Temperature Service not found (0x1809)");
         return "";

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -51,6 +51,19 @@ extern const char* CATHACK_SERVICE_UUID_3;
 #define MAX_SEEN_DEVICES 200
 #define MIN_FREE_HEAP_BYTES 20000
 
+// ===== BLE Scan Parameters =====
+#define BLE_SCAN_INTERVAL 45
+#define BLE_SCAN_WINDOW   15
+
+// ===== BLE GATT UUIDs =====
+#define UUID_GENERIC_ACCESS       "1800"
+#define UUID_DEVICE_NAME          "2a00"
+#define UUID_MODEL_NUMBER         "2a24"
+#define UUID_SERIAL_NUMBER        "2a25"
+#define UUID_MANUFACTURER_NAME    "2a29"
+#define UUID_BATTERY_LEVEL        "2a19"
+#define UUID_HEALTH_THERMOMETER   "1809"
+
 // ===== Constants =====
 #define RSSI_CONSTANT 20
 #define DISTANCE_CONSTANT -69

--- a/src/helper/BLEDecoder.cpp
+++ b/src/helper/BLEDecoder.cpp
@@ -1,4 +1,5 @@
 #include "BLEDecoder.h"
+#include "../config/config.h"
 #include "../logToSerialAndWeb/logger.h"
 #include "../sdCard/SDLogger.h"
 #include "../globals/globals.h"
@@ -64,7 +65,7 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
     logLine += asciiString;
 
     // ---- Known BLE characteristics ----
-    if (uuidStr.endsWith("2a19") && length >= 1)
+    if (uuidStr.endsWith(UUID_BATTERY_LEVEL) && length >= 1)
     {
         xpManager.awardXP(25);  // +25 XP: known char decoded (battery)
         String battery = String(data[0]) + "%";
@@ -75,7 +76,7 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
         logLine += "%";
     }
 
-    if (uuidStr == "2a19" && length == 1) {
+    if (uuidStr == UUID_BATTERY_LEVEL && length == 1) {
         uint8_t battery = data[0];
         Serial.printf("Battery Level: %d%%\n", battery);
         logLine += " | Battery Level=";
@@ -83,7 +84,7 @@ void decodeBLEData(const std::string& uuid, uint8_t* data, size_t length)
         logLine += "%";
     }
 
-    if (uuidStr.endsWith("2a00"))
+    if (uuidStr.endsWith(UUID_DEVICE_NAME))
     {
         xpManager.awardXP(25);  // +25 XP: known char decoded (name)
         String name = asciiString;

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -326,12 +326,12 @@ static bool connectAndReadGATT(
       std::string charUuid = characteristic->getUUID().toString();
       uuidList.push_back("Characteristic UUID: " + std::string(charUuid.c_str()));
 
-      if (charUuid == "2a24") {               // Model Number
+      if (charUuid == UUID_MODEL_NUMBER) {     // Model Number
           dev.gattHasModelInfo = true;
       }
 
-      if (charUuid == "2a29" ||               // Manufacturer Name
-          charUuid == "2a25") {               // Serial Number
+      if (charUuid == UUID_MANUFACTURER_NAME || // Manufacturer Name
+          charUuid == UUID_SERIAL_NUMBER) {    // Serial Number
           dev.gattHasIdentityInfo = true;
       }
 
@@ -440,8 +440,8 @@ void scanForDevices() {
 
   pScan->clearResults();        // 1. Clear previous results first
   pScan->setActiveScan(true);   // 2. Set active scan mode
-  pScan->setInterval(45);       // 3. Set scan interval // old 1000
-  pScan->setWindow(15);         // 4. Set scan window   // old 900
+  pScan->setInterval(BLE_SCAN_INTERVAL);
+  pScan->setWindow(BLE_SCAN_WINDOW);
   delay(100);                   // Optional small delay for stability
 
   NimBLEScanResults results = pScan->getResults(3000);  // Scan 3 seconds to get scan results -> maybe check 3sec for smaller list and earlier new scan


### PR DESCRIPTION
## Summary
- Add `BLE_SCAN_INTERVAL` and `BLE_SCAN_WINDOW` constants to `config.h`
- Add named constants for common GATT UUIDs (Generic Access, Device Name, Model Number, etc.)
- Replace hardcoded UUID strings and scan parameters across 4 files

## Test plan
- [ ] Verify BLE scan still works with the same interval/window values
- [ ] Verify GATT service discovery and characteristic reading still works
- [ ] Verify BLEDecoder correctly identifies battery and device name characteristics

Fixes #64