### PR TITLE
Move tierToString() to shared header to eliminate duplication

### DIFF
--- a/src/models/DeviceInfo.h
+++ b/src/models/DeviceInfo.h
@@ -8,6 +8,17 @@ enum class ExposureTier {
     Consent
 };
 
+inline const char* tierToString(ExposureTier tier)
+{
+    switch(tier)
+    {
+        case ExposureTier::Passive: return "PASSIVE";
+        case ExposureTier::Active:  return "ACTIVE";
+        case ExposureTier::Consent: return "CONSENT";
+        default: return "NONE";
+    }
+}
+
 struct DeviceInfo {
     std::string mac;
     std::string name;

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -192,17 +192,6 @@ String bytesToHexString(const std::string& data)
     return out;
 }
 
-static const char* tierToString(ExposureTier tier)
-{
-    switch(tier)
-    {
-        case ExposureTier::Passive: return "PASSIVE";
-        case ExposureTier::Active:  return "ACTIVE";
-        case ExposureTier::Consent: return "CONSENT";
-        default: return "NONE";
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Helper: parse advertised device info (address, name, manufacturer, iBeacon)
 // Returns false if the device should be skipped (null or already seen).

--- a/src/sdCard/SDLogger.cpp
+++ b/src/sdCard/SDLogger.cpp
@@ -6,17 +6,6 @@
 #include "../helper/ServiceHelper.h"  // Assuming you still need service name mapping
 
 
-static const char* tierToString(ExposureTier tier)
-{
-    switch(tier)
-    {
-        case ExposureTier::Passive: return "PASSIVE";
-        case ExposureTier::Active:  return "ACTIVE";
-        case ExposureTier::Consent: return "CONSENT";
-        default: return "NONE";
-    }
-}
-
 SDLogger::SDLogger() : initialized(false) {}
 
 SDLogger::~SDLogger() {


### PR DESCRIPTION
## Summary
- Move `tierToString()` from duplicate definitions in `ScanDevices.cpp` and `SDLogger.cpp` to a shared location
- Both files now include the shared function instead of defining their own

## Test plan
- [ ] Verify exposure tier labels still display correctly in scan output
- [ ] Verify SD card logging still shows correct tier strings

Fixes #55