### PR TITLE
Replace Serial.println() with logToSerialAndWeb() in GATT services

### DIFF
--- a/src/GATTServices/batteryLevelService.cpp
+++ b/src/GATTServices/batteryLevelService.cpp
@@ -11,45 +11,45 @@
 String BatteryServiceHandler::readBatteryLevel(NimBLEClient* pClient) {
   String batteryStr = "";
 
-  Serial.println("   🔋 Battery Service");
+  logToSerialAndWeb("   🔋 Battery Service");
 
   if (pClient == nullptr) {
-    Serial.println("     ⚠️ Client not available");
+    logToSerialAndWeb("     ⚠️ Client not available");
     return batteryStr;
   }
 
   // Standard BLE Battery Service (0x180F)
   NimBLERemoteService* batteryService = pClient->getService("180F");
   if (!batteryService) {
-    Serial.println("     ❌ Battery Service not supported");
+    logToSerialAndWeb("     ❌ Battery Service not supported");
     return batteryStr;
   }
 
-  Serial.println("     ✅ Battery Service detected (Standard BLE)");
+  logToSerialAndWeb("     ✅ Battery Service detected (Standard BLE)");
 
   // Battery Level Characteristic (0x2A19)
   NimBLERemoteCharacteristic* pChar = batteryService->getCharacteristic("2A19");
   if (!pChar) {
-    Serial.println("     ❌ Battery Level characteristic missing");
+    logToSerialAndWeb("     ❌ Battery Level characteristic missing");
     return batteryStr;
   }
 
   if (!pChar->canRead()) {
-    Serial.println("     ⚠️ Battery Level not readable");
+    logToSerialAndWeb("     ⚠️ Battery Level not readable");
     return batteryStr;
   }
 
   std::string raw = pChar->readValue();
 
   if (raw.empty() || raw.size() < 1) {
-    Serial.println("     ⚠️ Battery read failed (empty response)");
+    logToSerialAndWeb("     ⚠️ Battery read failed (empty response)");
     return batteryStr;
   }
 
   uint8_t level = static_cast<uint8_t>(raw[0]);
 
   if (level > 100) {
-    Serial.println("     ⚠️ Invalid battery value received");
+    logToSerialAndWeb("     ⚠️ Invalid battery value received");
     return batteryStr;
   }
 
@@ -58,7 +58,7 @@ String BatteryServiceHandler::readBatteryLevel(NimBLEClient* pClient) {
   batteryStr += "   Access: Public (standard BLE)\n";
   batteryStr += "   Control: Read-only\n";
 
-  Serial.print(batteryStr);
+  logToSerialAndWeb(batteryStr);
 
   return batteryStr;
 }

--- a/src/GATTServices/genericAccessService.cpp
+++ b/src/GATTServices/genericAccessService.cpp
@@ -10,11 +10,11 @@ String GenericAccessServiceHandler::readGenericAccessInfo(NimBLEClient* pClient)
 
     NimBLERemoteService* gapService = pClient->getService("1800");
     if (!gapService) {
-        Serial.println("   Generic Access Service not found (0x1800)");
+        logToSerialAndWeb("   Generic Access Service not found (0x1800)");
         return accessInfoString;
     }
 
-    Serial.println("   Generic Access Service found (0x1800)");
+    logToSerialAndWeb("   Generic Access Service found (0x1800)");
 
     const char* charUUIDs[] = {"2A00", "2A01", "2A04", "2AA6"};
     const char* charNames[] = {
@@ -24,7 +24,7 @@ String GenericAccessServiceHandler::readGenericAccessInfo(NimBLEClient* pClient)
         "Central Address Resolution"
     };
 
-    Serial.println("     Read value of generic access info");
+    logToSerialAndWeb("     Read value of generic access info");
     
     for (int i = 0; i < 4; i++) {
         NimBLERemoteCharacteristic* pChar = gapService->getCharacteristic(charUUIDs[i]);

--- a/src/GATTServices/heartRateService.cpp
+++ b/src/GATTServices/heartRateService.cpp
@@ -10,21 +10,21 @@
 
 
 String HeartRateServiceHandler::readHeartRate(NimBLEClient* pClient) {
-    Serial.println("   Heart Rate Service");
+    logToSerialAndWeb("   Heart Rate Service");
 
     if (!pClient) return "";
 
     NimBLERemoteService* hrService = pClient->getService("180D");
     if (!hrService) {
-        Serial.println("     Heart Rate Service not found");
+        logToSerialAndWeb("     Heart Rate Service not found");
         return "";
     }
 
-    Serial.println("     Heart Rate Service found (0x180D)");
+    logToSerialAndWeb("     Heart Rate Service found (0x180D)");
 
     NimBLERemoteCharacteristic* pChar = hrService->getCharacteristic("2A37");
     if (!pChar) {
-        Serial.println("     Heart Rate Measurement Characteristic not found");
+        logToSerialAndWeb("     Heart Rate Measurement Characteristic not found");
         return "";
     }
 
@@ -52,7 +52,7 @@ String HeartRateServiceHandler::readHeartRate(NimBLEClient* pClient) {
             }
         );
 
-        Serial.println("     Subscribed to Heart Rate notifications");
+        logToSerialAndWeb("     Subscribed to Heart Rate notifications");
     }
 
     return "";

--- a/src/GATTServices/temperatureService.cpp
+++ b/src/GATTServices/temperatureService.cpp
@@ -27,21 +27,21 @@ static float parseIEEE11073Float(const uint8_t* data) {
 }
 
 String TemperatureServiceHandler::readTemperature(NimBLEClient* pClient) {
-    Serial.println("   🌡️ Temperature Service");
+    logToSerialAndWeb("   🌡️ Temperature Service");
 
     if (!pClient) return "";
 
     NimBLERemoteService* tempService = pClient->getService("1809");
     if (!tempService) {
-        Serial.println("     Temperature Service not found (0x1809)");
+        logToSerialAndWeb("     Temperature Service not found (0x1809)");
         return "";
     }
 
-    Serial.println("     Temperature Service found (0x1809)");
+    logToSerialAndWeb("     Temperature Service found (0x1809)");
 
     NimBLERemoteCharacteristic* pChar = tempService->getCharacteristic("2A1C");
     if (!pChar) {
-        Serial.println("     Temperature Measurement Characteristic not found (0x2A1C)");
+        logToSerialAndWeb("     Temperature Measurement Characteristic not found (0x2A1C)");
         return "";
     }
 
@@ -69,10 +69,10 @@ String TemperatureServiceHandler::readTemperature(NimBLEClient* pClient) {
             }
         );
 
-        Serial.println("     Subscribed to temperature notifications");
+        logToSerialAndWeb("     Subscribed to temperature notifications");
     }
     else if (!pChar->canNotify()) {
-        Serial.println("     Temperature characteristic does NOT support notify");
+        logToSerialAndWeb("     Temperature characteristic does NOT support notify");
     }
 
     return "";


### PR DESCRIPTION
## Summary
- Replace Serial.println() calls with logToSerialAndWeb() in genericAccessService.cpp, heartRateService.cpp, temperatureService.cpp, and batteryLevelService.cpp
- Ensures status and error messages are visible in both Serial output and the WebSocket web interface
- Serial.printf() calls are left unchanged as logToSerialAndWeb() does not support printf format strings
- All four files already had the logger.h include

Fixes #69