### PR TITLE
Reduce unnecessary String/std::string conversions

### DIFF
--- a/src/GATTServices/deviceInfoService.cpp
+++ b/src/GATTServices/deviceInfoService.cpp
@@ -20,9 +20,7 @@ String DeviceInfoServiceHandler::readDeviceInfo(NimBLEClient* pClient) {
           }
       
           if (pChar->canRead()) {
-              std::string value = pChar->readValue();
-              String val = String(value.c_str());
-              deviceInfoString += String(charNames[i]) + ": " + val + "\n";
+              deviceInfoString += String(charNames[i]) + ": " + pChar->readValue().c_str() + "\n";
               //logToSerialAndWeb("     " + String(charNames[i]) + ": " + val);
           }
         }

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -253,17 +253,18 @@ void scanForDevices() {
       IBeaconInfo beacon;
 
       if (device != nullptr) {
-        address = device->getAddress().toString().c_str();
+        std::string addrStr = device->getAddress().toString();
+        address = addrStr.c_str();
         localName = device->haveName() ? String(device->getName().c_str()) : "";
         rssi = device->getRSSI();
         is_connectable = device->isConnectable();
 
         // Dedupe: Insert into seenDevices immediately (before any connect attempt)
-        if (seenDevices.find(std::string(address.c_str())) != seenDevices.end()) {
+        if (seenDevices.find(addrStr) != seenDevices.end()) {
           logToSerialAndWeb(String("🛑 Already seen: ") + address.c_str() + "\n");
           continue;
         }
-        seenDevices.insert(std::string(address.c_str()));
+        seenDevices.insert(addrStr);
 
         // Risk factor: Weak/default device name
         if (localName == "< -- >" || localName == "BLE Device" || localName == "Random") {
@@ -320,7 +321,7 @@ void scanForDevices() {
 
       handleDevicePrivacy(
           std::string(localName.c_str()),
-          std::string(address.c_str()),
+          addrStr,
           advData,
           payloadVec,
           is_connectable,


### PR DESCRIPTION
## Summary
- Cache `std::string` from `getAddress().toString()` once and reuse it for `seenDevices` lookups and `handleDevicePrivacy()`, eliminating repeated `String` to `std::string` conversions via `.c_str()`
- Remove intermediate `std::string` and `String` variables in `deviceInfoService.cpp` when reading BLE characteristic values

## Test plan
- [ ] Verify BLE scanning still correctly deduplicates devices
- [ ] Verify device info service readings display correctly
- [ ] Confirm no regressions in serial/web log output

Fixes #72