### PR TITLE
Reduce privacy severity for MAC-only unknown devices

### DIFF
--- a/src/analyzer/ExposureAnalyzer.cpp
+++ b/src/analyzer/ExposureAnalyzer.cpp
@@ -133,6 +133,21 @@ ExposureResult analyzeExposure(const DeviceInfo& dev)
     if (isApple)
         score -= 20;
 
+    // -------- Minimal information mitigation --------
+    // A public/static MAC alone enables tracking but reveals little about
+    // the device or its owner.  Reduce the score when no other identifying
+    // information is available so the rating reflects actual exposure.
+    bool hasMinimalInfo = !dev.hasName && !dev.hasManufacturerData &&
+                          !dev.advHasName && !dev.gattHasName &&
+                          !dev.gattHasNameIdentityData && !dev.gattHasPersonalName &&
+                          !dev.gattHasModelInfo && !dev.gattHasIdentityInfo &&
+                          !dev.gattHasEnvironmentName;
+
+    if (hasMinimalInfo && (dev.isPublicMac || dev.hasStaticMac)) {
+        score -= 15;
+        result.reasons.push_back("limited exposure (MAC only, no identifying data)");
+    }
+
     // -------- Identity Exposure --------
     if (score > 60)
         result.identityExposure = "HIGH";
@@ -144,8 +159,10 @@ ExposureResult analyzeExposure(const DeviceInfo& dev)
     // -------- Tracking Risk --------
     if (dev.hasRotatingMac)
         result.trackingRisk = "LOW";
-    else if (dev.hasStaticMac || dev.isPublicMac)
+    else if ((dev.hasStaticMac || dev.isPublicMac) && !hasMinimalInfo)
         result.trackingRisk = "HIGH";
+    else if (dev.hasStaticMac || dev.isPublicMac)
+        result.trackingRisk = "MEDIUM";
     else
         result.trackingRisk = "MEDIUM";
 


### PR DESCRIPTION
## Summary
- Adds a "minimal information" mitigation: when a device exposes **no** name, manufacturer data, GATT characteristics, or advertising name, the score from a public/static MAC alone is reduced by 15 points
- Tracking risk for minimal-info devices with static/public MAC is now **MEDIUM** instead of **HIGH**
- Devices that expose additional identifying information are completely unaffected

## Scoring impact

| Scenario | Before | After |
|----------|--------|-------|
| Public+static MAC only | Identity: HIGH, Tracking: HIGH, Privacy: POOR (score 60) | Identity: MEDIUM, Tracking: MEDIUM, Privacy: ACCEPTABLE (score 45) |
| Public+static MAC + connectable | Identity: HIGH, Tracking: HIGH, Privacy: POOR (score 70) | Identity: MEDIUM, Tracking: MEDIUM, Privacy: ACCEPTABLE (score 55) |
| Public+static MAC + name + mfr data | Unchanged | Unchanged |

The new reason string `"limited exposure (MAC only, no identifying data)"` is appended when the mitigation applies, making the adjustment visible in logs and the web UI.

Closes #104

## Test plan
- [ ] Scan unknown devices with only a public static MAC — verify they show MEDIUM/MEDIUM/ACCEPTABLE
- [ ] Scan devices that expose name, manufacturer data, or GATT info — verify they still rate HIGH/HIGH/POOR as before
- [ ] Verify the new reason string appears in serial output and SD card logs
- [ ] Test on M5Stack Cardputer hardware