### PR TITLE
Enhanced BLE data collection from advertisements and GATT

### DIFF
--- a/src/GATTServices/currentTimeService.cpp
+++ b/src/GATTServices/currentTimeService.cpp
@@ -1,0 +1,64 @@
+#include "currentTimeService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logToSerialAndWeb/logger.h"
+
+String CurrentTimeServiceHandler::readCurrentTime(NimBLEClient* pClient) {
+    String timeStr = "";
+
+    if (!pClient) return timeStr;
+
+    // Standard BLE Current Time Service (0x1805)
+    NimBLERemoteService* timeService = pClient->getService("1805");
+    if (!timeService) {
+        return timeStr;
+    }
+
+    logToSerialAndWeb("     Current Time Service detected (0x1805)");
+
+    // Current Time Characteristic (0x2A2B)
+    NimBLERemoteCharacteristic* pChar = timeService->getCharacteristic("2A2B");
+    if (!pChar || !pChar->canRead()) {
+        return timeStr;
+    }
+
+    std::string raw = pChar->readValue();
+    if (raw.size() < 7) {
+        return timeStr;
+    }
+
+    // Current Time format: year(2) month(1) day(1) hours(1) minutes(1) seconds(1)
+    uint16_t year = (uint8_t)raw[0] | ((uint8_t)raw[1] << 8);
+    uint8_t month = raw[2];
+    uint8_t day = raw[3];
+    uint8_t hours = raw[4];
+    uint8_t minutes = raw[5];
+    uint8_t seconds = raw[6];
+
+    char timeBuf[32];
+    snprintf(timeBuf, sizeof(timeBuf), "%04d-%02d-%02d %02d:%02d:%02d",
+             year, month, day, hours, minutes, seconds);
+
+    timeStr = "Device Time: " + String(timeBuf) + "\n";
+    logToSerialAndWeb("     Device Time: " + String(timeBuf));
+
+    // Day of Week (0x2A09) if available
+    NimBLERemoteCharacteristic* pDow = timeService->getCharacteristic("2A09");
+    if (pDow && pDow->canRead()) {
+        std::string dowRaw = pDow->readValue();
+        if (!dowRaw.empty()) {
+            const char* days[] = {"", "Monday", "Tuesday", "Wednesday",
+                                  "Thursday", "Friday", "Saturday", "Sunday"};
+            uint8_t dow = dowRaw[0];
+            if (dow >= 1 && dow <= 7) {
+                timeStr += "Day of Week: " + String(days[dow]) + "\n";
+                logToSerialAndWeb("     Day of Week: " + String(days[dow]));
+            }
+        }
+    }
+
+    return timeStr;
+}

--- a/src/GATTServices/currentTimeService.h
+++ b/src/GATTServices/currentTimeService.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class CurrentTimeServiceHandler {
+public:
+    static String readCurrentTime(NimBLEClient* pClient);
+};

--- a/src/GATTServices/genericAccessService.cpp
+++ b/src/GATTServices/genericAccessService.cpp
@@ -4,6 +4,7 @@
 
 #include "../config/config.h"
 #include "../logToSerialAndWeb/logger.h"
+#include "../helper/AppearanceHelper.h"
 
 
 String GenericAccessServiceHandler::readGenericAccessInfo(NimBLEClient* pClient) {
@@ -41,8 +42,9 @@ String GenericAccessServiceHandler::readGenericAccessInfo(NimBLEClient* pClient)
                 if (value.size() >= 2) {
                     uint16_t appearance;
                     memcpy(&appearance, value.data(), sizeof(appearance));
-                    accessInfoString += "Appearance: 0x" + String(appearance, HEX) + "\n";
-                    Serial.println("     Appearance: 0x" + String(appearance, HEX));
+                    String appearanceName = getAppearanceName(appearance);
+                    accessInfoString += "Appearance: " + appearanceName + " (0x" + String(appearance, HEX) + ")\n";
+                    Serial.println("     Appearance: " + appearanceName + " (0x" + String(appearance, HEX) + ")");
                 }
             } else if (strcmp(charUUIDs[i], "2A04") == 0) {
                 if (value.length() >= 8) {

--- a/src/GATTServices/immediateAlertService.cpp
+++ b/src/GATTServices/immediateAlertService.cpp
@@ -1,0 +1,36 @@
+#include "immediateAlertService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logToSerialAndWeb/logger.h"
+
+String ImmediateAlertServiceHandler::readImmediateAlert(NimBLEClient* pClient) {
+    String alertStr = "";
+
+    if (!pClient) return alertStr;
+
+    // Immediate Alert Service (0x1802)
+    NimBLERemoteService* alertService = pClient->getService("1802");
+    if (!alertService) {
+        return alertStr;
+    }
+
+    logToSerialAndWeb("     Immediate Alert Service detected (0x1802)");
+
+    // Alert Level Characteristic (0x2A06)
+    NimBLERemoteCharacteristic* pChar = alertService->getCharacteristic("2A06");
+    if (!pChar) {
+        return alertStr;
+    }
+
+    alertStr = "Immediate Alert: Supported";
+    if (pChar->canWrite()) {
+        alertStr += " (writable)";
+    }
+    alertStr += "\n";
+    logToSerialAndWeb("     " + alertStr);
+
+    return alertStr;
+}

--- a/src/GATTServices/immediateAlertService.h
+++ b/src/GATTServices/immediateAlertService.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class ImmediateAlertServiceHandler {
+public:
+    static String readImmediateAlert(NimBLEClient* pClient);
+};

--- a/src/GATTServices/linkLossService.cpp
+++ b/src/GATTServices/linkLossService.cpp
@@ -1,0 +1,40 @@
+#include "linkLossService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logToSerialAndWeb/logger.h"
+
+String LinkLossServiceHandler::readLinkLoss(NimBLEClient* pClient) {
+    String lossStr = "";
+
+    if (!pClient) return lossStr;
+
+    // Link Loss Service (0x1803)
+    NimBLERemoteService* lossService = pClient->getService("1803");
+    if (!lossService) {
+        return lossStr;
+    }
+
+    logToSerialAndWeb("     Link Loss Service detected (0x1803)");
+
+    // Alert Level Characteristic (0x2A06)
+    NimBLERemoteCharacteristic* pChar = lossService->getCharacteristic("2A06");
+    if (!pChar) {
+        return lossStr;
+    }
+
+    if (pChar->canRead()) {
+        std::string raw = pChar->readValue();
+        if (!raw.empty()) {
+            uint8_t level = raw[0];
+            const char* levels[] = {"No Alert", "Mild Alert", "High Alert"};
+            const char* levelStr = (level <= 2) ? levels[level] : "Unknown";
+            lossStr = "Link Loss Alert Level: " + String(levelStr) + "\n";
+            logToSerialAndWeb("     Link Loss Alert Level: " + String(levelStr));
+        }
+    }
+
+    return lossStr;
+}

--- a/src/GATTServices/linkLossService.h
+++ b/src/GATTServices/linkLossService.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class LinkLossServiceHandler {
+public:
+    static String readLinkLoss(NimBLEClient* pClient);
+};

--- a/src/GATTServices/txPowerService.cpp
+++ b/src/GATTServices/txPowerService.cpp
@@ -1,0 +1,41 @@
+#include "txPowerService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logToSerialAndWeb/logger.h"
+
+String TxPowerServiceHandler::readTxPowerLevel(NimBLEClient* pClient) {
+    String txPowerStr = "";
+
+    if (pClient == nullptr) {
+        return txPowerStr;
+    }
+
+    // Standard BLE Tx Power Service (0x1804)
+    NimBLERemoteService* txPowerService = pClient->getService("1804");
+    if (!txPowerService) {
+        return txPowerStr;
+    }
+
+    logToSerialAndWeb("     Tx Power Service detected (0x1804)");
+
+    // Tx Power Level Characteristic (0x2A07)
+    NimBLERemoteCharacteristic* pChar = txPowerService->getCharacteristic("2A07");
+    if (!pChar || !pChar->canRead()) {
+        return txPowerStr;
+    }
+
+    std::string raw = pChar->readValue();
+    if (raw.empty()) {
+        return txPowerStr;
+    }
+
+    int8_t txPower = static_cast<int8_t>(raw[0]);
+
+    txPowerStr = "Tx Power Level: " + String(txPower) + " dBm\n";
+    logToSerialAndWeb("     Tx Power Level: " + String(txPower) + " dBm");
+
+    return txPowerStr;
+}

--- a/src/GATTServices/txPowerService.h
+++ b/src/GATTServices/txPowerService.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class TxPowerServiceHandler {
+public:
+    static String readTxPowerLevel(NimBLEClient* pClient);
+};

--- a/src/helper/AppearanceHelper.cpp
+++ b/src/helper/AppearanceHelper.cpp
@@ -1,0 +1,51 @@
+#include "AppearanceHelper.h"
+
+String getAppearanceName(uint16_t appearance) {
+    // BLE Assigned Numbers — Appearance Values (category = bits 15..6)
+    uint16_t category = appearance >> 6;
+
+    switch (category) {
+        case 0:   return "Unknown";
+        case 1:   return "Phone";
+        case 2:   return "Computer";
+        case 3:   return "Watch";
+        case 4:   return "Clock";
+        case 5:   return "Display";
+        case 6:   return "Remote Control";
+        case 7:   return "Eye Glasses";
+        case 8:   return "Tag";
+        case 9:   return "Keyring";
+        case 10:  return "Media Player";
+        case 11:  return "Barcode Scanner";
+        case 12:  return "Thermometer";
+        case 13:  return "Heart Rate Sensor";
+        case 14:  return "Blood Pressure";
+        case 15:  return "HID Device";
+        case 16:  return "Glucose Meter";
+        case 17:  return "Running/Walking Sensor";
+        case 18:  return "Cycling Sensor";
+        case 49:  return "Pulse Oximeter";
+        case 50:  return "Weight Scale";
+        case 51:  return "Personal Mobility";
+        case 52:  return "Continuous Glucose Monitor";
+        case 53:  return "Insulin Pump";
+        case 54:  return "Medication Delivery";
+        case 81:  return "Outdoor Sports Activity";
+        default:  break;
+    }
+
+    // Sub-type matching for HID devices (category 15)
+    switch (appearance) {
+        case 961:  return "Keyboard";
+        case 962:  return "Mouse";
+        case 963:  return "Joystick";
+        case 964:  return "Gamepad";
+        case 965:  return "Digitizer Tablet";
+        case 966:  return "Card Reader";
+        case 967:  return "Digital Pen";
+        case 968:  return "Barcode Scanner (HID)";
+        default:   break;
+    }
+
+    return "Unknown (0x" + String(appearance, HEX) + ")";
+}

--- a/src/helper/AppearanceHelper.h
+++ b/src/helper/AppearanceHelper.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <Arduino.h>
+
+String getAppearanceName(uint16_t appearance);

--- a/src/privacyCheck/devicePrivacy.cpp
+++ b/src/privacyCheck/devicePrivacy.cpp
@@ -171,6 +171,9 @@ void handleDevicePrivacy(
         std::find(info.seen_macs.begin(), info.seen_macs.end(), mac) == info.seen_macs.end()) {
         info.mac_change_count++;
         info.seen_macs.push_back(mac);
+        logToSerialAndWeb("   MAC rotation detected for device (" +
+            String(info.mac_change_count) + " changes, " +
+            String(info.seen_macs.size()) + " unique MACs)");
     } else if (info.seen_macs.empty()) {
         info.seen_macs.push_back(mac);
     }

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -16,6 +16,14 @@
 #include "../models/DeviceInfo.h"
 #include "../privacyCheck/ExposureClassifier.h"
 #include "../helper/BLEDecoder.h"
+#include "../GATTServices/genericAccessService.h"
+#include "../GATTServices/batteryLevelService.h"
+#include "../GATTServices/heartRateService.h"
+#include "../GATTServices/temperatureService.h"
+#include "../GATTServices/txPowerService.h"
+#include "../GATTServices/currentTimeService.h"
+#include "../GATTServices/immediateAlertService.h"
+#include "../GATTServices/linkLossService.h"
 #include "../gps/GPSManager.h"
 #include "../wardriving/WigleLogger.h"
 #include "../helper/nibblesSpeech.h"
@@ -263,6 +271,53 @@ static bool parseDeviceInfo(
     }
   }
 
+  // -------- Advertisement Service UUIDs --------
+  int svcCount = device->getServiceUUIDCount();
+  if (svcCount > 0) {
+    logToSerialAndWeb("   Advertised Services (" + String(svcCount) + "):");
+    for (int s = 0; s < svcCount; s++) {
+      NimBLEUUID svcUUID = device->getServiceUUID(s);
+      std::string uuidStr = svcUUID.toString();
+      // NimBLE returns "0x1800" for 16-bit UUIDs — strip the "0x" prefix
+      String shortUUID = uuidStr.c_str();
+      if (shortUUID.startsWith("0x")) {
+        shortUUID = shortUUID.substring(2);
+      }
+      String svcName = getServiceName(shortUUID);
+      logToSerialAndWeb("     - " + shortUUID + " (" + svcName + ")");
+    }
+  }
+
+  // -------- Advertisement TX Power --------
+  if (device->haveTXPower()) {
+    int8_t advTxPower = device->getTXPower();
+    logToSerialAndWeb("   Adv TX Power: " + String(advTxPower) + " dBm");
+    float estDist = estimateDistance(advTxPower, device->getRSSI());
+    if (estDist >= 0) {
+      logToSerialAndWeb("   Est. Distance (TX): ~" + String(estDist, 2) + " m");
+    }
+  }
+
+  // -------- Advertisement Service Data (AD Type 0x16) --------
+  int svcDataCount = device->getServiceDataCount();
+  if (svcDataCount > 0) {
+    logToSerialAndWeb("   Service Data (" + String(svcDataCount) + "):");
+    for (int sd = 0; sd < svcDataCount; sd++) {
+      NimBLEUUID svcDataUUID = device->getServiceDataUUID(sd);
+      std::string svcData = device->getServiceData(sd);
+
+      String shortUUID = svcDataUUID.toString().c_str();
+      if (shortUUID.startsWith("0x")) {
+        shortUUID = shortUUID.substring(2);
+      }
+      String svcName = getServiceName(shortUUID);
+
+      String hexData = bytesToHexString(svcData);
+      logToSerialAndWeb("     - UUID: " + shortUUID + " (" + svcName + ")");
+      logToSerialAndWeb("       Data: " + hexData);
+    }
+  }
+
   return true;
 }
 
@@ -283,6 +338,33 @@ static bool connectAndReadGATT(
 
   if (!deviceInfoService.isEmpty()) {
       dev.gattHasName = true;
+  }
+
+  // Read additional standard GATT services
+  genericAccessService = GenericAccessServiceHandler::readGenericAccessInfo(pClient);
+  batteryLevelService = BatteryServiceHandler::readBatteryLevel(pClient);
+  heartRateService = HeartRateServiceHandler::readHeartRate(pClient);
+  temperatureService = TemperatureServiceHandler::readTemperature(pClient);
+
+  String txPowerInfo = TxPowerServiceHandler::readTxPowerLevel(pClient);
+  if (!txPowerInfo.isEmpty()) {
+      logToSerialAndWeb(txPowerInfo);
+  }
+
+  // Read additional optional GATT services
+  String timeInfo = CurrentTimeServiceHandler::readCurrentTime(pClient);
+  if (!timeInfo.isEmpty()) {
+      logToSerialAndWeb(timeInfo);
+  }
+
+  String alertInfo = ImmediateAlertServiceHandler::readImmediateAlert(pClient);
+  if (!alertInfo.isEmpty()) {
+      logToSerialAndWeb(alertInfo);
+  }
+
+  String linkLossInfo = LinkLossServiceHandler::readLinkLoss(pClient);
+  if (!linkLossInfo.isEmpty()) {
+      logToSerialAndWeb(linkLossInfo);
   }
 
   logToSerialAndWeb("🔓 Connected and discovered attributes!");
@@ -321,6 +403,16 @@ static bool connectAndReadGATT(
 
       if (characteristic->canWrite() || characteristic->canWriteNoResponse()) {
           hasWritableChar = true;
+      }
+
+      // Read Characteristic User Description descriptor (0x2901)
+      NimBLERemoteDescriptor* userDesc = characteristic->getDescriptor(NimBLEUUID("2901"));
+      if (userDesc) {
+          std::string descValue = userDesc->readValue();
+          if (!descValue.empty() && isPrintableText(descValue)) {
+              logToSerialAndWeb("     Descriptor [" + String(charUuid.c_str()) + "]: " + String(descValue.c_str()));
+              nameList.push_back(descValue);
+          }
       }
 
       std::string rawValue = characteristic->readValue();


### PR DESCRIPTION
## Summary
- Extract advertised service UUIDs, TX Power with distance estimation, and Service Data payloads from BLE advertisements
- Wire up 4 existing but unused GATT service handlers (Generic Access, Battery, Heart Rate, Temperature)
- Add 4 new GATT service handlers: TX Power Level (0x1804), Current Time (0x1805), Immediate Alert (0x1802), Link Loss (0x1803)
- Read Characteristic User Description descriptors (0x2901) during GATT enumeration
- Decode BLE Appearance values to human-readable device categories instead of raw hex
- Log MAC rotation events with change count tracking

## Details

### Advertisement data (passive, no connection needed)
| Data | Source | Method |
|------|--------|--------|
| Service UUIDs | AD Type 0x02/0x03/0x06/0x07 | `getServiceUUID()` with human-readable names |
| TX Power Level | AD Type 0x0A | `getTXPower()` + distance estimation |
| Service Data | AD Type 0x16 | `getServiceData()` with UUID + hex payload |

### GATT services (active, after connection)
| Service | UUID | Data extracted |
|---------|------|----------------|
| Generic Access | 0x1800 | Device name, appearance (now decoded), connection params |
| Battery | 0x180F | Battery level percentage |
| Heart Rate | 0x180D | BPM via notifications |
| Temperature | 0x1809 | IEEE-11073 float via notifications |
| TX Power Level | 0x1804 | Transmit power in dBm |
| Current Time | 0x1805 | Device date/time + day of week |
| Immediate Alert | 0x1802 | Alert capability + write support |
| Link Loss | 0x1803 | Alert level (No/Mild/High) |

### Other improvements
- **Appearance decoding**: Raw hex values like `0xC1` are now shown as "Watch (0xc1)"
- **Descriptor reading**: User Description descriptors (0x2901) are read and logged for each characteristic
- **MAC rotation tracking**: When a device fingerprint is seen with a new MAC address, the change is logged with count

## Test plan
- [ ] Verify advertised service UUIDs are logged with correct names
- [ ] Verify TX Power and distance estimation appear for devices that broadcast TX Power
- [ ] Verify Service Data payloads are parsed and displayed
- [ ] Verify GATT services are read when available (battery level, heart rate, etc.)
- [ ] Verify Appearance values show decoded device type names
- [ ] Verify descriptor text is logged during characteristic enumeration
- [ ] Verify MAC rotation events are logged with change counts
- [ ] Confirm no heap/memory issues on M5Stack Cardputer with additional service reads