### PR TITLE
Add security vulnerability detection and device fingerprinting

### DIFF
--- a/src/analyzer/ExposureAnalyzer.cpp
+++ b/src/analyzer/ExposureAnalyzer.cpp
@@ -133,6 +133,32 @@ ExposureResult analyzeExposure(const DeviceInfo& dev)
     if (isApple)
         score -= 20;
 
+    // -------- Security vulnerability factors --------
+    if (dev.hasDFUService) {
+        score += 20;
+        result.reasons.push_back("firmware update service exposed (DFU)");
+    }
+
+    if (dev.hasUARTService) {
+        score += 15;
+        result.reasons.push_back("serial/UART service exposed");
+    }
+
+    if (dev.hasWritableChars && !dev.connectionEncrypted) {
+        score += 15;
+        result.reasons.push_back("writable characteristics without encryption");
+    }
+
+    if (dev.hasSensitiveUnencrypted) {
+        score += 20;
+        result.reasons.push_back("sensitive service without encryption");
+    }
+
+    if (dev.supportsBrEdr) {
+        score += 5;
+        result.reasons.push_back("dual-mode device (BLE + Classic)");
+    }
+
     // -------- Minimal information mitigation --------
     // A public/static MAC alone enables tracking but reveals little about
     // the device or its owner.  Reduce the score when no other identifying

--- a/src/analyzer/SecurityAnalyzer.cpp
+++ b/src/analyzer/SecurityAnalyzer.cpp
@@ -1,0 +1,201 @@
+#include "SecurityAnalyzer.h"
+#include <NimBLEDevice.h>
+#include "../logToSerialAndWeb/logger.h"
+
+// Well-known sensitive service UUIDs
+static bool isSensitiveService(const std::string& uuid) {
+    return uuid == "0x180d" || uuid == "180d" ||   // Heart Rate
+           uuid == "0x1810" || uuid == "1810" ||   // Blood Pressure
+           uuid == "0x1808" || uuid == "1808" ||   // Glucose
+           uuid == "0x1809" || uuid == "1809" ||   // Health Thermometer
+           uuid == "0x1812" || uuid == "1812" ||   // HID (keyboard/mouse)
+           uuid == "0x1805" || uuid == "1805";     // Current Time
+}
+
+// Well-known DFU / firmware update service UUIDs
+static bool isDFUService(const std::string& uuid) {
+    // Nordic DFU
+    if (uuid.find("fe59") != std::string::npos) return true;
+    // Legacy Nordic DFU
+    if (uuid.find("1530") != std::string::npos &&
+        uuid.find("1234") != std::string::npos) return true;
+    // ESP32 OTA
+    if (uuid.find("d804b643") != std::string::npos) return true;
+    // STM DFU
+    if (uuid.find("0000fe20") != std::string::npos) return true;
+    return false;
+}
+
+// Well-known UART/serial service UUIDs
+static bool isUARTService(const std::string& uuid) {
+    // Nordic UART Service (NUS)
+    if (uuid.find("6e400001") != std::string::npos) return true;
+    // HM-10/HM-16 serial
+    if (uuid.find("ffe0") != std::string::npos) return true;
+    if (uuid.find("ffe1") != std::string::npos) return true;
+    // Microchip transparent UART
+    if (uuid.find("49535343") != std::string::npos) return true;
+    return false;
+}
+
+SecurityResult analyzeDeviceSecurity(NimBLEClient* pClient, const DeviceInfo& dev) {
+    SecurityResult result;
+
+    if (!pClient || !pClient->isConnected()) return result;
+
+    // -------- 1. Connection encryption check --------
+    result.connectionEncrypted = pClient->isEncrypted();
+
+    if (!result.connectionEncrypted) {
+        result.findings.push_back({
+            "MEDIUM", "NO_ENCRYPTION",
+            "connection is not encrypted"
+        });
+    }
+
+    // -------- 2. Iterate services & characteristics --------
+    auto services = pClient->getServices();
+    for (auto* service : services) {
+        if (!service) continue;
+        std::string svcUuid = service->getUUID().toString();
+
+        // Check for DFU service
+        if (isDFUService(svcUuid)) {
+            result.hasDFUService = true;
+            result.findings.push_back({
+                "HIGH", "DFU_EXPOSED",
+                "firmware update service exposed (" + svcUuid + ")"
+            });
+        }
+
+        // Check for UART/serial service
+        if (isUARTService(svcUuid)) {
+            result.hasUARTService = true;
+            result.findings.push_back({
+                "HIGH", "UART_EXPOSED",
+                "serial/UART service exposed (" + svcUuid + ")"
+            });
+        }
+
+        // Check for sensitive service without encryption
+        if (isSensitiveService(svcUuid) && !result.connectionEncrypted) {
+            result.hasSensitiveServiceUnencrypted = true;
+            result.findings.push_back({
+                "HIGH", "SENSITIVE_UNENCRYPTED",
+                "sensitive service without encryption (" + svcUuid + ")"
+            });
+        }
+
+        // Analyze characteristics
+        auto chars = service->getCharacteristics();
+        for (auto* ch : chars) {
+            if (!ch) continue;
+            result.totalCharCount++;
+
+            bool writable = ch->canWrite() || ch->canWriteNoResponse();
+            if (writable) {
+                result.writableCharCount++;
+
+                // Writable without encryption is a security risk
+                if (!result.connectionEncrypted) {
+                    result.hasWritableWithoutAuth = true;
+                    std::string charUuid = ch->getUUID().toString();
+                    result.findings.push_back({
+                        "HIGH", "WRITABLE_NO_AUTH",
+                        "writable characteristic without auth (" + charUuid +
+                        " in " + svcUuid + ")"
+                    });
+                }
+
+                // Write-no-response is especially risky (fire-and-forget)
+                if (ch->canWriteNoResponse()) {
+                    std::string charUuid = ch->getUUID().toString();
+                    result.findings.push_back({
+                        "MEDIUM", "WRITE_NO_RESPONSE",
+                        "write-no-response characteristic (" + charUuid + ")"
+                    });
+                }
+            }
+        }
+    }
+
+    // -------- 3. Build device fingerprint --------
+    result.deviceFingerprint = buildDeviceFingerprint(pClient, dev.name, dev.manufacturer);
+
+    return result;
+}
+
+// -------- Advertisement Flags Analysis (AD Type 0x01) --------
+void analyzeAdvFlags(const std::vector<uint8_t>& payload, DeviceInfo& dev,
+                     std::vector<SecurityFinding>& findings) {
+    // Parse AD structures: [length][type][data...]
+    size_t i = 0;
+    while (i < payload.size()) {
+        uint8_t len = payload[i];
+        if (len == 0 || i + len >= payload.size()) break;
+
+        uint8_t adType = payload[i + 1];
+
+        if (adType == 0x01 && len >= 2) {
+            // AD Type 0x01 = Flags
+            uint8_t flags = payload[i + 2];
+
+            bool leLimited      = flags & 0x01;
+            bool leGeneral       = flags & 0x02;
+            bool brEdrNotSupport = flags & 0x04;
+            bool leBrEdrCtrl     = flags & 0x08;
+            bool leBrEdrHost     = flags & 0x10;
+
+            if (!brEdrNotSupport) {
+                findings.push_back({
+                    "INFO", "BR_EDR_SUPPORTED",
+                    "device supports BR/EDR (classic Bluetooth)"
+                });
+            }
+
+            if (leLimited) {
+                findings.push_back({
+                    "INFO", "LE_LIMITED_DISCOVERABLE",
+                    "limited discoverable mode (temporary visibility)"
+                });
+            }
+
+            if (leBrEdrCtrl || leBrEdrHost) {
+                findings.push_back({
+                    "LOW", "DUAL_MODE",
+                    "dual-mode device (BLE + Classic)"
+                });
+            }
+        }
+
+        i += len + 1;
+    }
+}
+
+// -------- Device Fingerprint --------
+std::string buildDeviceFingerprint(NimBLEClient* pClient,
+                                   const std::string& name,
+                                   const std::string& manufacturer) {
+    std::string fp;
+
+    // Include sorted service UUIDs
+    if (pClient && pClient->isConnected()) {
+        auto services = pClient->getServices();
+        std::vector<std::string> svcUuids;
+        for (auto* svc : services) {
+            if (svc) svcUuids.push_back(svc->getUUID().toString());
+        }
+        std::sort(svcUuids.begin(), svcUuids.end());
+        for (auto& u : svcUuids) {
+            if (!fp.empty()) fp += "|";
+            fp += u;
+        }
+    }
+
+    // Append manufacturer for more specific fingerprint
+    if (!manufacturer.empty()) {
+        fp += "#" + manufacturer;
+    }
+
+    return fp;
+}

--- a/src/analyzer/SecurityAnalyzer.h
+++ b/src/analyzer/SecurityAnalyzer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <NimBLEClient.h>
+#include "../models/DeviceInfo.h"
+
+struct SecurityFinding {
+    std::string severity;    // "HIGH", "MEDIUM", "LOW", "INFO"
+    std::string category;    // e.g. "WRITABLE_CHAR", "NO_ENCRYPTION", "DFU_EXPOSED"
+    std::string description;
+};
+
+struct SecurityResult {
+    bool connectionEncrypted = false;
+    bool hasDFUService = false;
+    bool hasUARTService = false;
+    bool hasWritableWithoutAuth = false;
+    bool hasSensitiveServiceUnencrypted = false;
+    int writableCharCount = 0;
+    int totalCharCount = 0;
+    std::string deviceFingerprint;
+    std::vector<SecurityFinding> findings;
+};
+
+// Analyze GATT security after connecting to a device
+SecurityResult analyzeDeviceSecurity(NimBLEClient* pClient, const DeviceInfo& dev);
+
+// Parse advertisement flags (AD Type 0x01) from raw payload
+void analyzeAdvFlags(const std::vector<uint8_t>& payload, DeviceInfo& dev,
+                     std::vector<SecurityFinding>& findings);
+
+// Build a unique fingerprint from advertised service UUIDs + GATT profile
+std::string buildDeviceFingerprint(NimBLEClient* pClient,
+                                   const std::string& name,
+                                   const std::string& manufacturer);

--- a/src/models/DeviceInfo.h
+++ b/src/models/DeviceInfo.h
@@ -42,4 +42,14 @@ struct DeviceInfo {
     bool hasName = false;
     bool hasManufacturerData = false;
     bool hasCleartextData = false;
+
+    // Security analysis flags
+    bool hasWritableChars = false;
+    bool hasDFUService = false;
+    bool hasUARTService = false;
+    bool connectionEncrypted = false;
+    bool hasSensitiveUnencrypted = false;
+    bool supportsBrEdr = false;
+    int writableCharCount = 0;
+    std::string deviceFingerprint;
 };

--- a/src/privacyCheck/devicePrivacy.cpp
+++ b/src/privacyCheck/devicePrivacy.cpp
@@ -7,7 +7,16 @@
 
 std::map<std::string, DeviceInfo> mac_history;
 std::map<std::string, DevicePrivacyInfo> device_identity_history;
-std::vector<std::string> weakNames = {"<NoName>", "BLE_Device", "Unknown", "SensorTag", "ESP32"};
+std::vector<std::string> weakNames = {
+    "<NoName>", "BLE_Device", "Unknown", "SensorTag", "ESP32",
+    "BLE Device", "Arduino", "OBDII", "OBD2", "MLT-BT05",
+    "HC-05", "HC-06", "HC-08", "HMSoft", "JDY-08", "JDY-10",
+    "AT-09", "BT05", "CC2541", "CC2640", "nRF5x", "DSD TECH",
+    "Espressif", "ESP_GATTS_DEMO", "LYWSD03MMC", "Mi Band",
+    "MI_SCALE", "Flower care", "iBBQ", "BBQ", "LED", "ELM327",
+    "SimpleBLE", "BLE5-PERIPH", "Bluefruit52", "Adafruit",
+    "MyDevice", "Test", "test", "Device", "BLE", "Peripheral"
+};
 std::vector<std::string> emptyNames = {"", "< -- >"};
 
 enum class DeviceCategory {

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -24,6 +24,7 @@
 #include "../GATTServices/currentTimeService.h"
 #include "../GATTServices/immediateAlertService.h"
 #include "../GATTServices/linkLossService.h"
+#include "../analyzer/SecurityAnalyzer.h"
 #include "../gps/GPSManager.h"
 #include "../wardriving/WigleLogger.h"
 #include "../helper/nibblesSpeech.h"
@@ -227,7 +228,10 @@ static bool parseDeviceInfo(
   seenDevices.insert(addrStr);
 
   // Risk factor: Weak/default device name
-  if (localName == "< -- >" || localName == "BLE Device" || localName == "Random") {
+  if (localName == "< -- >" || localName == "BLE Device" || localName == "Random" ||
+      localName.startsWith("ESP_") || localName.startsWith("ESP32") ||
+      localName.startsWith("Arduino") || localName.startsWith("HM") ||
+      localName.startsWith("HC-") || localName.startsWith("BLE")) {
     hasWeakName = true;
   }
 
@@ -563,6 +567,13 @@ void scanForDevices() {
       std::vector<uint8_t> payloadVec = device->getPayload();
       std::string advData(payloadVec.begin(), payloadVec.end());
 
+      // -------- Advertisement Flags Analysis (AD Type 0x01) --------
+      std::vector<SecurityFinding> advFindings;
+      analyzeAdvFlags(payloadVec, dev, advFindings);
+      for (auto& f : advFindings) {
+        logToSerialAndWeb("   [" + String(f.severity.c_str()) + "] " + String(f.description.c_str()));
+      }
+
       handleDevicePrivacy(
           std::string(localName.c_str()),
           addrStr,
@@ -645,6 +656,28 @@ void scanForDevices() {
                     manufacturerName,
                     rssi
                 );
+              }
+
+              // -------- Security Analysis --------
+              SecurityResult secResult = analyzeDeviceSecurity(pClient, dev);
+
+              dev.connectionEncrypted = secResult.connectionEncrypted;
+              dev.hasWritableChars = (secResult.writableCharCount > 0);
+              dev.writableCharCount = secResult.writableCharCount;
+              dev.hasDFUService = secResult.hasDFUService;
+              dev.hasUARTService = secResult.hasUARTService;
+              dev.hasSensitiveUnencrypted = secResult.hasSensitiveServiceUnencrypted;
+              dev.deviceFingerprint = secResult.deviceFingerprint;
+
+              if (!secResult.findings.empty()) {
+                logToSerialAndWeb("Security Findings:");
+                for (auto& f : secResult.findings) {
+                  logToSerialAndWeb("   [" + String(f.severity.c_str()) + "] " + String(f.description.c_str()));
+                }
+              }
+
+              if (!secResult.deviceFingerprint.empty()) {
+                logToSerialAndWeb("   Device Fingerprint: " + String(secResult.deviceFingerprint.c_str()));
               }
 
               // Analyze exposure and log results


### PR DESCRIPTION
## Summary
- Add `SecurityAnalyzer` that detects writable chars without auth, unencrypted sensitive services, exposed DFU/UART services, and connection encryption status
- Parse BLE advertisement flags (AD Type 0x01) for BR/EDR support and discoverable mode
- Build unique device fingerprints from GATT service profiles for tracking analysis
- Expand weak/default device name detection from 5 to 40+ entries with prefix matching

## New Security Findings

| Finding | Severity | Description |
|---------|----------|-------------|
| `WRITABLE_NO_AUTH` | HIGH | Writable characteristic on unencrypted connection |
| `WRITE_NO_RESPONSE` | MEDIUM | Fire-and-forget write characteristic |
| `NO_ENCRYPTION` | MEDIUM | BLE connection is not encrypted |
| `DFU_EXPOSED` | HIGH | Firmware update service accessible (Nordic, ESP32 OTA, STM) |
| `UART_EXPOSED` | HIGH | Serial/UART service accessible (NUS, HM-10, Microchip) |
| `SENSITIVE_UNENCRYPTED` | HIGH | Health/HID service without encryption |
| `BR_EDR_SUPPORTED` | INFO | Device supports Classic Bluetooth |
| `DUAL_MODE` | LOW | Dual-mode BLE + Classic device |
| `LE_LIMITED_DISCOVERABLE` | INFO | Temporary visibility mode |

## Exposure Score Impact

| Factor | Points |
|--------|--------|
| DFU service exposed | +20 |
| Sensitive service unencrypted | +20 |
| UART service exposed | +15 |
| Writable chars without encryption | +15 |
| Dual-mode device | +5 |

## Test plan
- [ ] Scan devices with writable characteristics — verify security findings logged
- [ ] Scan a device with DFU/OTA service — verify HIGH finding
- [ ] Scan an unencrypted device with Heart Rate service — verify SENSITIVE_UNENCRYPTED
- [ ] Verify advertisement flags parsed correctly (BR/EDR, discoverable mode)
- [ ] Verify device fingerprint is generated and logged
- [ ] Verify expanded weak name list catches ESP_, HC-, Arduino devices
- [ ] Confirm no heap/memory issues on M5Stack Cardputer