### PR TITLE
Fix sprite composite colors and background artifacts

### DIFF
--- a/src/helper/drawOverlay.cpp
+++ b/src/helper/drawOverlay.cpp
@@ -1,5 +1,6 @@
 #include "drawOverlay.h"
 #include <M5Unified.h>
+#include "../config/config.h"
 
 void drawOverlay(const uint16_t* img, int w, int h, int x0, int y0) {
     M5.Lcd.pushImage(x0, y0, w, h, img, (uint16_t)0xFFFF);
@@ -16,8 +17,17 @@ static const int EXPR_REGION_H = 38;   // 90  - 52
 void drawComposite(const uint16_t* base, int baseW, int baseX, int baseY,
                    const uint16_t* overlay, int overlayW, int overlayH,
                    int overlayX, int overlayY) {
+    // Clear areas outside the expression region that may have been
+    // dirtied by speech/device-name bubbles or HUD text
+    M5.Lcd.fillRect(BUBBLE_X, BUBBLE_RECT_Y - 3,
+                    BUBBLE_RECT_W + 4, BUBBLE_RECT_H + BUBBLE_TRI_H + 6, 0x00C4);
+    M5.Lcd.fillRect(STATS_X, STATS_Y_START,
+                    70, STATS_LINE_HEIGHT * 4, 0x00C4);
+
+    // Sprite-composite the expression region
     M5Canvas canvas(&M5.Lcd);
     if (!canvas.createSprite(EXPR_REGION_W, EXPR_REGION_H)) return;
+    canvas.setSwapBytes(true);
 
     // Fill entire expression region from base image (row-by-row sub-region copy)
     int bOffX = EXPR_REGION_X - baseX;


### PR DESCRIPTION
## Summary
- Fix RGB565 color byte order in sprite compositing (`setSwapBytes(true)`)
- Clear bubble and stats regions before compositing to prevent stale overlays

## Problem
The `drawComposite()` function introduced in #106 had two issues:
1. **Wrong colors**: `M5Canvas` defaults to `setSwapBytes(false)` while `M5.Lcd` uses `true`, causing RGB565 bytes to render in wrong order
2. **Background artifacts**: Only the 86x38 expression region was redrawn, leaving speech bubbles, device name labels, and stale HUD counter text visible from previous states

## Fix
- Add `canvas.setSwapBytes(true)` to match the LCD's byte order
- Clear the bubble area (125, 12, 112x32) and stats area (5, 62, 70x48) with background color `0x00C4` before each composite operation

## Test plan
- [ ] Verify Nibbles expression colors render correctly
- [ ] Verify speech bubbles are cleared on expression change
- [ ] Verify device name labels don't persist across transitions
- [ ] Verify HUD counter values don't show old digits