### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Build and Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Build firmware
+        run: pio run
+
+      - name: Rename binary
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          cp .pio/build/ghostble/firmware.bin "GhostBLE-${VERSION}.bin"
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: GhostBLE-*.bin


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers on release creation
- Builds firmware using PlatformIO
- Attaches the versioned binary (e.g. `GhostBLE-v1.0.0.bin`) to the release

## Test plan
- [ ] Create a draft release and verify the workflow runs
- [ ] Confirm the binary is attached to the release