### PR TITLE
Optimize memory, CPU, and scan performance

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -2,6 +2,7 @@
 #include <M5Unified.h>
 #include <SPI.h>
 #include <vector>
+#include <unordered_set>
 #include <NimBLEDevice.h>
 
 #include "src/globals/globals.h"
@@ -32,8 +33,7 @@
 #include <AsyncTCP.h>
 
 
-unsigned long startTimeDevice;
-const unsigned long timerDurationDevice = 30 * 60 * 1000; // 30 minutes in milliseconds
+// Reactive memory cleanup uses heap threshold + set size (see loop)
 
 const char* ap_ssid = WIFI_AP_SSID;
 const char* ap_password = WIFI_AP_PASSWORD;
@@ -149,7 +149,6 @@ void setup() {
 
   nibblesSpeechBegin();
 
-  startTimeDevice = millis();
   scanIsRunning = false;
 
   delay(3000);
@@ -224,20 +223,16 @@ void loop() {
     }
   }
 
-  // Timer every 60 minutes
-  unsigned long currentTimeDevice = millis();
-  if (currentTimeDevice - startTimeDevice >= timerDurationDevice) {
-    LOG(LOG_SYSTEM, "Timer: periodic seenDevices reset");
-    if (!seenDevices.empty()) {
-      // Swap with empty set to free memory instantly via pointer swap,
-      // avoiding per-node deallocation blocking the main loop
-      std::set<std::string>().swap(seenDevices);
-      deviceSessionMap.clear();
-      LOG(LOG_SYSTEM, "CLEAR SEEN DEVICES");
-    } else {
-      LOG(LOG_SYSTEM, "SEEN DEVICES STILL EMPTY");
-    }
-    startTimeDevice = millis();
+  // Reactive memory cleanup: clear seenDevices when heap runs low or set grows too large,
+  // rather than on a fixed timer. This avoids both premature clearing (losing dedup)
+  // and late clearing (OOM risk).
+  if (!seenDevices.empty() &&
+      (seenDevices.size() >= MAX_SEEN_DEVICES || ESP.getFreeHeap() < MIN_FREE_HEAP_BYTES)) {
+    LOG(LOG_SYSTEM, "Reactive cleanup (size: " + String(seenDevices.size()) +
+                    ", free heap: " + String(ESP.getFreeHeap()) + ")");
+    std::unordered_set<std::string>().swap(seenDevices);
+    deviceSessionMap.clear();
+    LOG(LOG_SYSTEM, "CLEAR SEEN DEVICES");
   }
   // Auto-enable serial logging when USB host is connected
   static bool lastUsbState = false;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -72,8 +72,10 @@ extern const char* PWNBEACON_NAME_CHAR_UUID;
 #define MIN_FREE_HEAP_BYTES 20000
 
 // ===== BLE Scan Parameters =====
+// Higher window/interval ratio = more advertisements captured per cycle.
+// 40/45 ≈ 89% duty cycle (vs prior 15/45 = 33%). Fine for USB-powered Cardputer.
 #define BLE_SCAN_INTERVAL 45
-#define BLE_SCAN_WINDOW   15
+#define BLE_SCAN_WINDOW   40
 
 // ===== BLE GATT UUIDs =====
 #define UUID_GENERIC_ACCESS       "1800"

--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -1,5 +1,5 @@
 #include "globals.h"
-#include <set>
+#include <unordered_set>
 #include <map>
 #include <string>
 #include <vector>
@@ -7,7 +7,7 @@
 
 XPManager xpManager;
 
-std::set<std::string> seenDevices;
+std::unordered_set<std::string> seenDevices;
 
 std::atomic<int> nextDeviceSessionId{1};
 std::map<std::string, int> deviceSessionMap;

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <set>
+#include <unordered_set>
 #include <map>
 #include <string>
 #include <Arduino.h>
@@ -10,8 +10,8 @@
 
 extern XPManager xpManager;
 
-// ScanDevices seenDevices
-extern std::set<std::string> seenDevices;
+// ScanDevices seenDevices (unordered_set for O(1) lookups instead of O(log n))
+extern std::unordered_set<std::string> seenDevices;
 
 // Device session ID tracking (MAC → incremental session ID)
 extern std::atomic<int> nextDeviceSessionId;

--- a/src/helper/ServiceHelper.cpp
+++ b/src/helper/ServiceHelper.cpp
@@ -1,39 +1,65 @@
 #include "ServiceHelper.h"
 #include "../config/config.h"
 
+// Sorted lookup table for standard 16-bit BLE service UUIDs.
+// Binary search is O(log n) with no heap allocation vs cascading String comparisons.
+struct ServiceEntry {
+    uint16_t uuid;
+    const char* name;
+};
+
+static const ServiceEntry serviceTable[] = {
+    { 0x1800, "Generic Access Service" },
+    { 0x1801, "Generic Attribute Service" },
+    { 0x1802, "Immediate Alert" },
+    { 0x1803, "Link Loss" },
+    { 0x1804, "Tx Power" },
+    { 0x1805, "Current Time Service" },
+    { 0x1806, "Scan Parameters" },
+    { 0x1809, "Health Thermometer" },
+    { 0x180a, "Device Information Service" },
+    { 0x180d, "Heart Rate Service" },
+    { 0x180f, "Battery Service" },
+    { 0x1810, "Blood Pressure" },
+    { 0x1811, "Alert Notification Service" },
+    { 0x1812, "Human Interface Device (HID)" },
+    { 0x1813, "Glucose" },
+    { 0x1814, "Running Speed and Cadence Service (RSCS)" },
+    { 0x1815, "Temperature Measurement" },
+    { 0x1816, "Temperature Type" },
+    { 0x1823, "Running Speed and Cadence" },
+    { 0x1824, "Cycling Speed and Cadence" },
+    { 0x1825, "Cycling Power" },
+    { 0x1826, "Cycling Torque Measurement" },
+    { 0x1827, "Cycling Torque Vector" },
+    { 0x1832, "Barometric Pressure" },
+    { 0x1833, "Air Quality" },
+    { 0x1834, "Oxygen Saturation" },
+    { 0x1835, "Pollen Data" },
+    { 0x1836, "Personal Activity Monitoring" },
+    { 0x1837, "Fitness Machine" },
+    { 0x1838, "Health and Fitness Measurement" },
+};
+
+static const int serviceTableSize = sizeof(serviceTable) / sizeof(serviceTable[0]);
+
 String getServiceName(const String& uuid) {
-    if (uuid == "1800") return "Generic Access Service";
-    if (uuid == "1801") return "Generic Attribute Service";
-    if (uuid == "180f") return "Battery Service";
-    if (uuid == "180d") return "Heart Rate Service";
-    if (uuid == "180a") return "Device Information Service";
-    if (uuid == "1802") return "Immediate Alert";
-    if (uuid == "1803") return "Link Loss";
-    if (uuid == "1804") return "Tx Power";
-    if (uuid == "1805") return "Current Time Service";
-    if (uuid == "1812") return "Human Interface Device (HID)";  // BRUCE KEYBOARD
-    if (uuid == "1809") return "Health Thermometer";
-    if (uuid == "1811") return "Alert Notification Service";
-    if (uuid == "1810") return "Blood Pressure";
-    if (uuid == "1813") return "Glucose";
-    if (uuid == "1823") return "Running Speed and Cadence";
-    if (uuid == "1824") return "Cycling Speed and Cadence";
-    if (uuid == "1806") return "Scan Parameters";
-    if (uuid == "1815") return "Temperature Measurement";
-    if (uuid == "1816") return "Temperature Type";
-    if (uuid == "1825") return "Cycling Power";
-    if (uuid == "1826") return "Cycling Torque Measurement";
-    if (uuid == "1827") return "Cycling Torque Vector";
-    if (uuid == "1832") return "Barometric Pressure";
-    if (uuid == "1833") return "Air Quality";
-    if (uuid == "1834") return "Oxygen Saturation";
-    if (uuid == "1835") return "Pollen Data";
-    if (uuid == "1836") return "Personal Activity Monitoring";
-    if (uuid == "1837") return "Fitness Machine";
-    if (uuid == "1838") return "Health and Fitness Measurement";
-    if (uuid == "1814") return "Running Speed and Cadence Service (RSCS)";
+    // Try parsing as a 16-bit UUID for fast binary search
+    if (uuid.length() <= 4) {
+        uint16_t id = (uint16_t)strtoul(uuid.c_str(), nullptr, 16);
+        if (id != 0) {
+            int lo = 0, hi = serviceTableSize - 1;
+            while (lo <= hi) {
+                int mid = (lo + hi) / 2;
+                if (serviceTable[mid].uuid == id) return serviceTable[mid].name;
+                if (serviceTable[mid].uuid < id) lo = mid + 1;
+                else hi = mid - 1;
+            }
+        }
+    }
+
+    // Fall through for 128-bit UUIDs (vendor-specific)
     if (uuid == PWNBEACON_SERVICE_UUID) return "PwnBeacon (PwnGrid/BLE)";
     if (uuid == TESLA_BLE_SERVICE_UUID) return "Tesla Vehicle (BLE Key)";
     return "Unknown Service";
-  }
-  
+}

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -144,7 +144,7 @@ void LOG(LogCategory category, const String& msg) {
     uint8_t targets = getTargets(category);
     if (targets == TARGET_NONE) return;
 
-    if (logMutex != NULL && xSemaphoreTake(logMutex, pdMS_TO_TICKS(500)) == pdTRUE) {
+    if (logMutex != NULL && xSemaphoreTake(logMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
         if ((targets & TARGET_SERIAL) && Serial.availableForWrite() > 0) {
             Serial.println(msg);
         }

--- a/src/scanner/ScanDevices.cpp
+++ b/src/scanner/ScanDevices.cpp
@@ -1,6 +1,6 @@
 #include <NimBLEDevice.h>
 #include <M5Cardputer.h>
-#include <set>
+#include <unordered_set>
 #include <vector>
 #include <algorithm>
 
@@ -128,16 +128,16 @@ IBeaconInfo parseIBeacon(const std::string& mfg) {
 }
 
 float estimateDistance(int txPower, int rssi) {
-  if (rssi == 0 || txPower == 0) return -1.0;
-  float ratio = rssi * 1.0 / txPower;
+  if (rssi == 0 || txPower == 0) return -1.0f;
+  float ratio = (float)rssi / (float)txPower;
   float distance;
-  if (ratio < 1.0)
-    distance = pow(ratio, 10);
+  if (ratio < 1.0f)
+    distance = powf(ratio, 10.0f);
   else
-    distance = 0.89976 * pow(ratio, 7.7095) + 0.111;
+    distance = 0.89976f * powf(ratio, 7.7095f) + 0.111f;
   // Discard unrealistic values (negative, NaN, infinity, >1000m)
-  if (distance < 0 || distance > 1000.0 || isnan(distance) || isinf(distance))
-    return -1.0;
+  if (distance < 0.0f || distance > 1000.0f || isnan(distance) || isinf(distance))
+    return -1.0f;
   return distance;
 }
 
@@ -463,6 +463,7 @@ static bool connectAndReadGATT(
     if (isTargetDevice(localName.c_str(), address.c_str(), serviceUuid.c_str(), deviceInfoService.c_str())) {
       targetFound = true;
       susDevice++;
+      // Only award target XP on first discovery (dedup via seenDevices)
       xpManager.awardXP(20);  // +20 XP: suspicious device found
       LOG(LOG_TARGET, devTag + "!!! Target detected !!!");
       nibblesSpeechShow(SpeechContext::SUSPICIOUS);
@@ -661,7 +662,7 @@ void scanForDevices() {
                   infoLog += names.c_str();
                 }
               }
-              float distance = pow(10.0f, (float)(DISTANCE_CONSTANT - rssi) / RSSI_CONSTANT);
+              float distance = powf(10.0f, (float)(DISTANCE_CONSTANT - rssi) / (float)RSSI_CONSTANT);
               infoLog += "\n   Distance: " + String(distance, 2) + " m";
               infoLog += "\n   RSSI: " + String(rssi);
               LOG(LOG_SCAN, infoLog);

--- a/src/xp/XPManager.cpp
+++ b/src/xp/XPManager.cpp
@@ -76,7 +76,7 @@ uint8_t XPManager::getProgressPercent() {
 
 uint32_t XPManager::xpForLevel(uint16_t level) {
     if (level <= 1) return 0;
-    return (uint32_t)floor(16.67 * pow((double)level, 1.477));
+    return (uint32_t)floorf(16.67f * powf((float)level, 1.477f));
 }
 
 void XPManager::recalculateLevel() {


### PR DESCRIPTION
## Summary
- **O(1) device dedup**: Replace `std::set` with `std::unordered_set` for `seenDevices` — hash lookups instead of tree traversal
- **Float math**: Use `powf()` instead of `pow()` everywhere — ESP32-S3 has no double FPU, so `pow()` triggers expensive software emulation
- **Reactive memory cleanup**: Replace fixed 30-minute timer with heap-threshold + set-size check (`< 20KB free` or `>= 200 devices`), preventing both premature clearing and OOM
- **Better scan duty cycle**: Increase BLE scan window from 15 to 40 (89% vs 33% duty cycle) — catches ~2.7x more advertisements per cycle, negligible power cost on USB-powered Cardputer
- **Reduced logger blocking**: Semaphore timeout from 500ms to 100ms, reducing worst-case main loop stall
- **Binary search service lookup**: Sorted `uint16_t` table with binary search replaces 30+ cascading `String` comparisons in `ServiceHelper` — zero heap allocation for standard UUIDs

## Test plan
- [ ] Verify build compiles (confirmed locally: SUCCESS, RAM 17.0%, Flash 52.3%)
- [ ] Run scan with 10+ nearby BLE devices — confirm all are discovered and deduplicated
- [ ] Monitor serial log for reactive cleanup messages during extended scan sessions
- [ ] Verify service names still resolve correctly (e.g. Heart Rate, Device Info, PwnBeacon)
- [ ] Check XP awards and level progression still work as expected