### PR TITLE
Reduce unnecessary logging

### DIFF
--- a/GhostBLE.ino
+++ b/GhostBLE.ino
@@ -9,6 +9,7 @@
 #include "src/scanner/ScanDevices.h"
 #include "src/helper/drawOverlay.h"
 #include "src/helper/showExpression.h"
+#include "src/helper/screenshot.h"
 
 #include "src/images/nibblesStartWorking.h"
 #include "src/images/nibblesFront.h"
@@ -105,6 +106,8 @@ void setup() {
   Serial.begin(115200);
   delay(500);
 
+  Screenshot::init();
+
   M5.Lcd.setSwapBytes(true);
 
   LOG(LOG_SYSTEM, "GhostBLE starting...");
@@ -182,6 +185,7 @@ void loop() {
 
       if (status.enter) {
         LOG(LOG_CONTROL, "ENTER pressed");
+        Screenshot::capture();
       }
       if (status.fn) {
         LOG(LOG_CONTROL, "FN pressed");
@@ -308,7 +312,9 @@ void onLongPress() {
     ws.textAll("BLE_SCAN_ON");
     drawComposite(nibblesFront, NIBBLESFRONT_WIDTH, 5, 0,
                   nibblesThugLife, NIBBLESTHUGLIFE_WIDTH, NIBBLESTHUGLIFE_HEIGHT, 80, 52);
-    delay(2000);
+    delay(1500);
+    logNewBoot();
+    delay(500);
     showFindingCounter(targetConnects, susDevice, allSpottedDevice);
     nibblesSpeechShow(SpeechContext::SCAN_START);
   }

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -132,7 +132,6 @@ void logDisableCategory(LogCategory category) {
     enabledCategories &= ~(uint16_t)category;
 }
 
-<<<<<<< Updated upstream
 void logNewBoot() {
     char msg[64];
 
@@ -152,9 +151,6 @@ void logNewBoot() {
         LOG(cat, "");
     }
 }
-
-=======
->>>>>>> Stashed changes
 // Internal: resolve effective targets for a category
 static uint8_t getTargets(LogCategory category) {
     if (!(enabledCategories & (uint16_t)category)) return TARGET_NONE;


### PR DESCRIPTION
## Summary
- Disable `system.log`, `control.log`, and `gps.log` categories by default to reduce SD card write load and improve performance
- Enable GPS logging dynamically only when wardriving is activated
- Add `VERBOSE_LOGGING` build flag to restore full logging when needed (add `-DVERBOSE_LOGGING` to `build_flags` in platformio.ini)

Closes #123

## Test plan
- [x] Verify `system.log`, `control.log`, and `gps.log` are not written during normal scanning
- [x] Enable wardriving and confirm `gps.log` entries appear
- [x] Disable wardriving and confirm GPS logging stops
- [ ] Build with `-DVERBOSE_LOGGING` and verify all log categories are active