### PR TITLE
Add more GATT services and fallback handler

### DIFF
--- a/src/GATTServices/GATTServiceInit.cpp
+++ b/src/GATTServices/GATTServiceInit.cpp
@@ -1,6 +1,7 @@
 #include "GATTServiceInit.h"
 #include "GATTServiceRegistry.h"
 #include "genericAccessService.h"
+#include "genericAttributeService.h"
 #include "deviceInfoService.h"
 #include "batteryLevelService.h"
 #include "heartRateService.h"
@@ -9,12 +10,21 @@
 #include "txPowerService.h"
 #include "immediateAlertService.h"
 #include "linkLossService.h"
+#include "hidService.h"
+#include "environmentalSensingService.h"
+#include "alertNotificationService.h"
+#include "phoneAlertStatusService.h"
+#include "genericDumpHandler.h"
 
 void registerGATTServiceHandlers()
 {
     GATTServiceRegistry::registerService(
         "1800", "Generic Access",
         [](NimBLEClient* c) { return GenericAccessServiceHandler::readGenericAccessInfo(c); });
+
+    GATTServiceRegistry::registerService(
+        "1801", "Generic Attribute",
+        [](NimBLEClient* c) { return GenericAttributeServiceHandler::readGenericAttribute(c); });
 
     GATTServiceRegistry::registerService(
         "180a", "Device Information",
@@ -47,4 +57,24 @@ void registerGATTServiceHandlers()
     GATTServiceRegistry::registerService(
         "1803", "Link Loss",
         [](NimBLEClient* c) { return LinkLossServiceHandler::readLinkLoss(c); });
+
+    GATTServiceRegistry::registerService(
+        "1812", "Human Interface Device",
+        [](NimBLEClient* c) { return HIDServiceHandler::readHID(c); });
+
+    GATTServiceRegistry::registerService(
+        "181a", "Environmental Sensing",
+        [](NimBLEClient* c) { return EnvironmentalSensingServiceHandler::readEnvironmentalSensing(c); });
+
+    GATTServiceRegistry::registerService(
+        "1811", "Alert Notification",
+        [](NimBLEClient* c) { return AlertNotificationServiceHandler::readAlertNotification(c); });
+
+    GATTServiceRegistry::registerService(
+        "180e", "Phone Alert Status",
+        [](NimBLEClient* c) { return PhoneAlertStatusServiceHandler::readPhoneAlertStatus(c); });
+
+    // Fallback: dump characteristics for any unregistered service
+    GATTServiceRegistry::registerFallback(
+        [](NimBLEClient* c, std::string uuid) { return GenericDumpHandler::dumpService(c, uuid); });
 }

--- a/src/GATTServices/GATTServiceRegistry.cpp
+++ b/src/GATTServices/GATTServiceRegistry.cpp
@@ -1,5 +1,7 @@
 #include "GATTServiceRegistry.h"
 #include "../logger/logger.h"
+#include <NimBLERemoteService.h>
+#include <set>
 
 std::vector<GATTServiceEntry>& GATTServiceRegistry::registry()
 {
@@ -26,6 +28,18 @@ std::map<std::string, String>& GATTServiceRegistry::results()
     return res;
 }
 
+std::function<String(NimBLEClient*, std::string)>& GATTServiceRegistry::fallback()
+{
+    static std::function<String(NimBLEClient*, std::string)> fb;
+    return fb;
+}
+
+void GATTServiceRegistry::registerFallback(
+    std::function<String(NimBLEClient*, std::string)> handler)
+{
+    fallback() = handler;
+}
+
 String GATTServiceRegistry::getLastResult(const std::string& uuid)
 {
     auto it = results().find(uuid);
@@ -40,6 +54,12 @@ String GATTServiceRegistry::runDiscoveredHandlers(NimBLEClient* pClient)
     results().clear();
     String combined;
 
+    // Collect registered UUIDs for fallback exclusion
+    std::set<std::string> registeredUUIDs;
+    for (auto& entry : registry()) {
+        registeredUUIDs.insert(entry.uuid);
+    }
+
     for (auto& entry : registry()) {
         // Check if this service UUID is present on the device
         NimBLERemoteService* svc = pClient->getService(entry.uuid.c_str());
@@ -50,6 +70,32 @@ String GATTServiceRegistry::runDiscoveredHandlers(NimBLEClient* pClient)
         if (!result.isEmpty()) {
             if (!combined.isEmpty()) combined += "\n";
             combined += result;
+        }
+    }
+
+    // Run fallback handler for any unregistered services
+    if (fallback()) {
+        for (auto* svc : pClient->getServices()) {
+            std::string uuid = svc->getUUID().toString();
+
+            // Normalize: strip "0x" prefix if present
+            if (uuid.substr(0, 2) == "0x") {
+                uuid = uuid.substr(2);
+            }
+
+            // Skip already-handled services
+            if (registeredUUIDs.count(uuid)) continue;
+
+            // Also check lowercase variant
+            std::string lower = uuid;
+            for (auto& ch : lower) ch = tolower(ch);
+            if (registeredUUIDs.count(lower)) continue;
+
+            String result = fallback()(pClient, uuid);
+            if (!result.isEmpty()) {
+                if (!combined.isEmpty()) combined += "\n";
+                combined += result;
+            }
         }
     }
 

--- a/src/GATTServices/GATTServiceRegistry.h
+++ b/src/GATTServices/GATTServiceRegistry.h
@@ -24,7 +24,12 @@ public:
                                 const std::string& label,
                                 std::function<String(NimBLEClient*)> handler);
 
+    // Register a fallback handler for unregistered services.
+    // Called with the client and the service UUID string.
+    static void registerFallback(std::function<String(NimBLEClient*, std::string)> handler);
+
     // Run all registered handlers whose UUID was discovered on the client.
+    // Unregistered services are routed to the fallback handler (if set).
     // Returns combined log output from all matched handlers.
     static String runDiscoveredHandlers(NimBLEClient* pClient);
 
@@ -38,4 +43,5 @@ public:
 private:
     static std::vector<GATTServiceEntry>& registry();
     static std::map<std::string, String>& results();
+    static std::function<String(NimBLEClient*, std::string)>& fallback();
 };

--- a/src/GATTServices/alertNotificationService.cpp
+++ b/src/GATTServices/alertNotificationService.cpp
@@ -1,0 +1,49 @@
+#include "alertNotificationService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logger/logger.h"
+
+String AlertNotificationServiceHandler::readAlertNotification(NimBLEClient* pClient) {
+    String result = "";
+
+    if (!pClient) return result;
+
+    NimBLERemoteService* service = pClient->getService("1811");
+    if (!service) return result;
+
+    LOG(LOG_GATT, "     Alert Notification Service detected (0x1811)");
+
+    // Supported New Alert Category (0x2A47)
+    NimBLERemoteCharacteristic* pCat = service->getCharacteristic("2A47");
+    if (pCat && pCat->canRead()) {
+        std::string raw = pCat->readValue();
+        if (!raw.empty()) {
+            uint8_t categories = raw[0];
+            result = "Alert Categories: ";
+
+            const char* catNames[] = {
+                "Simple Alert", "Email", "News", "Call",
+                "Missed Call", "SMS/MMS", "Voice Mail", "Schedule"
+            };
+            bool first = true;
+            for (int i = 0; i < 8; i++) {
+                if (categories & (1 << i)) {
+                    if (!first) result += ", ";
+                    result += catNames[i];
+                    first = false;
+                }
+            }
+            result += "\n";
+            LOG(LOG_GATT, "     " + result);
+        }
+    }
+
+    if (result.isEmpty()) {
+        result = "Alert Notification: Present\n";
+    }
+
+    return result;
+}

--- a/src/GATTServices/alertNotificationService.h
+++ b/src/GATTServices/alertNotificationService.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class AlertNotificationServiceHandler {
+public:
+    static String readAlertNotification(NimBLEClient* pClient);
+};

--- a/src/GATTServices/environmentalSensingService.cpp
+++ b/src/GATTServices/environmentalSensingService.cpp
@@ -1,0 +1,61 @@
+#include "environmentalSensingService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logger/logger.h"
+
+String EnvironmentalSensingServiceHandler::readEnvironmentalSensing(NimBLEClient* pClient) {
+    String result = "";
+
+    if (!pClient) return result;
+
+    NimBLERemoteService* service = pClient->getService("181A");
+    if (!service) return result;
+
+    LOG(LOG_GATT, "     Environmental Sensing Service detected (0x181A)");
+
+    // Temperature (0x2A6E) — sint16, units 0.01 °C
+    NimBLERemoteCharacteristic* pTemp = service->getCharacteristic("2A6E");
+    if (pTemp && pTemp->canRead()) {
+        std::string raw = pTemp->readValue();
+        if (raw.size() >= 2) {
+            int16_t tempRaw = (uint8_t)raw[0] | ((uint8_t)raw[1] << 8);
+            float tempC = tempRaw / 100.0f;
+            result += "🌡 Temperature: " + String(tempC, 1) + " °C\n";
+            LOG(LOG_GATT, "     Temperature: " + String(tempC, 1) + " °C");
+        }
+    }
+
+    // Humidity (0x2A6F) — uint16, units 0.01 %
+    NimBLERemoteCharacteristic* pHum = service->getCharacteristic("2A6F");
+    if (pHum && pHum->canRead()) {
+        std::string raw = pHum->readValue();
+        if (raw.size() >= 2) {
+            uint16_t humRaw = (uint8_t)raw[0] | ((uint8_t)raw[1] << 8);
+            float humidity = humRaw / 100.0f;
+            result += "💧 Humidity: " + String(humidity, 1) + " %\n";
+            LOG(LOG_GATT, "     Humidity: " + String(humidity, 1) + " %");
+        }
+    }
+
+    // Pressure (0x2A6D) — uint32, units 0.1 Pa
+    NimBLERemoteCharacteristic* pPres = service->getCharacteristic("2A6D");
+    if (pPres && pPres->canRead()) {
+        std::string raw = pPres->readValue();
+        if (raw.size() >= 4) {
+            uint32_t presRaw = (uint8_t)raw[0] | ((uint8_t)raw[1] << 8) |
+                               ((uint8_t)raw[2] << 16) | ((uint8_t)raw[3] << 24);
+            float presHpa = presRaw / 1000.0f;
+            result += "🌀 Pressure: " + String(presHpa, 1) + " hPa\n";
+            LOG(LOG_GATT, "     Pressure: " + String(presHpa, 1) + " hPa");
+        }
+    }
+
+    if (result.isEmpty()) {
+        result = "Environmental Sensing: Present\n";
+    }
+
+    return result;
+}

--- a/src/GATTServices/environmentalSensingService.h
+++ b/src/GATTServices/environmentalSensingService.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class EnvironmentalSensingServiceHandler {
+public:
+    static String readEnvironmentalSensing(NimBLEClient* pClient);
+};

--- a/src/GATTServices/genericAttributeService.cpp
+++ b/src/GATTServices/genericAttributeService.cpp
@@ -1,0 +1,31 @@
+#include "genericAttributeService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logger/logger.h"
+
+String GenericAttributeServiceHandler::readGenericAttribute(NimBLEClient* pClient) {
+    String result = "";
+
+    if (!pClient) return result;
+
+    NimBLERemoteService* service = pClient->getService("1801");
+    if (!service) return result;
+
+    LOG(LOG_GATT, "     Generic Attribute Service detected (0x1801)");
+
+    // Service Changed Characteristic (0x2A05)
+    NimBLERemoteCharacteristic* pChar = service->getCharacteristic("2A05");
+    if (pChar) {
+        result = "Service Changed: Supported";
+        if (pChar->canIndicate()) {
+            result += " (indicate)";
+        }
+        result += "\n";
+        LOG(LOG_GATT, "     " + result);
+    }
+
+    return result;
+}

--- a/src/GATTServices/genericAttributeService.h
+++ b/src/GATTServices/genericAttributeService.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class GenericAttributeServiceHandler {
+public:
+    static String readGenericAttribute(NimBLEClient* pClient);
+};

--- a/src/GATTServices/genericDumpHandler.cpp
+++ b/src/GATTServices/genericDumpHandler.cpp
@@ -1,0 +1,56 @@
+#include "genericDumpHandler.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logger/logger.h"
+
+String GenericDumpHandler::dumpService(NimBLEClient* pClient, const std::string& uuid) {
+    String result = "";
+
+    if (!pClient) return result;
+
+    NimBLERemoteService* service = pClient->getService(uuid.c_str());
+    if (!service) return result;
+
+    LOG(LOG_GATT, "     Unknown Service (0x" + String(uuid.c_str()) + ")");
+
+    auto characteristics = service->getCharacteristics(true);
+    for (auto* pChar : characteristics) {
+        std::string charUuid = pChar->getUUID().toString();
+        String props = "";
+        if (pChar->canRead()) props += "R";
+        if (pChar->canWrite()) props += "W";
+        if (pChar->canNotify()) props += "N";
+        if (pChar->canIndicate()) props += "I";
+
+        String line = "  Char " + String(charUuid.c_str()) + " [" + props + "]";
+
+        if (pChar->canRead()) {
+            std::string raw = pChar->readValue();
+            if (!raw.empty()) {
+                // Show as hex dump (max 16 bytes)
+                String hex = "";
+                size_t len = (raw.size() > 16) ? 16 : raw.size();
+                for (size_t i = 0; i < len; i++) {
+                    char buf[4];
+                    snprintf(buf, sizeof(buf), "%02X ", (uint8_t)raw[i]);
+                    hex += buf;
+                }
+                if (raw.size() > 16) hex += "...";
+                line += " = " + hex;
+            }
+        }
+
+        line += "\n";
+        result += line;
+        LOG(LOG_GATT, "     " + line);
+    }
+
+    if (result.isEmpty()) {
+        result = "Unknown Service (" + String(uuid.c_str()) + "): No characteristics\n";
+    }
+
+    return result;
+}

--- a/src/GATTServices/genericDumpHandler.h
+++ b/src/GATTServices/genericDumpHandler.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <NimBLEClient.h>
+#include <Arduino.h>
+#include <string>
+
+class GenericDumpHandler {
+public:
+    static String dumpService(NimBLEClient* pClient, const std::string& uuid);
+};

--- a/src/GATTServices/hidService.cpp
+++ b/src/GATTServices/hidService.cpp
@@ -1,0 +1,50 @@
+#include "hidService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logger/logger.h"
+
+String HIDServiceHandler::readHID(NimBLEClient* pClient) {
+    String result = "";
+
+    if (!pClient) return result;
+
+    NimBLERemoteService* service = pClient->getService("1812");
+    if (!service) return result;
+
+    LOG(LOG_GATT, "     HID Service detected (0x1812)");
+
+    result = "HID: Present";
+
+    // HID Information Characteristic (0x2A4A)
+    NimBLERemoteCharacteristic* pInfo = service->getCharacteristic("2A4A");
+    if (pInfo && pInfo->canRead()) {
+        std::string raw = pInfo->readValue();
+        if (raw.size() >= 4) {
+            uint16_t hidVersion = (uint8_t)raw[0] | ((uint8_t)raw[1] << 8);
+            uint8_t countryCode = raw[2];
+            uint8_t flags = raw[3];
+            char buf[48];
+            snprintf(buf, sizeof(buf), " (v%d.%d, country=%d, flags=0x%02X)",
+                     hidVersion >> 8, hidVersion & 0xFF, countryCode, flags);
+            result += String(buf);
+            LOG(LOG_GATT, "     HID Info:" + String(buf));
+        }
+    }
+
+    // Protocol Mode Characteristic (0x2A4E)
+    NimBLERemoteCharacteristic* pMode = service->getCharacteristic("2A4E");
+    if (pMode && pMode->canRead()) {
+        std::string raw = pMode->readValue();
+        if (!raw.empty()) {
+            const char* mode = (raw[0] == 0) ? "Boot" : "Report";
+            result += ", Mode: " + String(mode);
+            LOG(LOG_GATT, "     Protocol Mode: " + String(mode));
+        }
+    }
+
+    result += "\n";
+    return result;
+}

--- a/src/GATTServices/hidService.h
+++ b/src/GATTServices/hidService.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class HIDServiceHandler {
+public:
+    static String readHID(NimBLEClient* pClient);
+};

--- a/src/GATTServices/phoneAlertStatusService.cpp
+++ b/src/GATTServices/phoneAlertStatusService.cpp
@@ -1,0 +1,51 @@
+#include "phoneAlertStatusService.h"
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteService.h>
+#include <NimBLERemoteCharacteristic.h>
+
+#include "../logger/logger.h"
+
+String PhoneAlertStatusServiceHandler::readPhoneAlertStatus(NimBLEClient* pClient) {
+    String result = "";
+
+    if (!pClient) return result;
+
+    NimBLERemoteService* service = pClient->getService("180E");
+    if (!service) return result;
+
+    LOG(LOG_GATT, "     Phone Alert Status Service detected (0x180E)");
+
+    // Alert Status Characteristic (0x2A3F)
+    NimBLERemoteCharacteristic* pStatus = service->getCharacteristic("2A3F");
+    if (pStatus && pStatus->canRead()) {
+        std::string raw = pStatus->readValue();
+        if (!raw.empty()) {
+            uint8_t status = raw[0];
+            result = "Phone Alert: ";
+            if (status & 0x01) result += "Ringer ";
+            if (status & 0x02) result += "Vibrate ";
+            if (status & 0x04) result += "Display ";
+            if (status == 0) result += "Silent";
+            result += "\n";
+            LOG(LOG_GATT, "     " + result);
+        }
+    }
+
+    // Ringer Setting Characteristic (0x2A41)
+    NimBLERemoteCharacteristic* pRinger = service->getCharacteristic("2A41");
+    if (pRinger && pRinger->canRead()) {
+        std::string raw = pRinger->readValue();
+        if (!raw.empty()) {
+            const char* setting = (raw[0] == 0) ? "Silent" : "Normal";
+            result += "Ringer Setting: " + String(setting) + "\n";
+            LOG(LOG_GATT, "     Ringer Setting: " + String(setting));
+        }
+    }
+
+    if (result.isEmpty()) {
+        result = "Phone Alert Status: Present\n";
+    }
+
+    return result;
+}

--- a/src/GATTServices/phoneAlertStatusService.h
+++ b/src/GATTServices/phoneAlertStatusService.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <NimBLEClient.h>
+#include <Arduino.h>
+
+class PhoneAlertStatusServiceHandler {
+public:
+    static String readPhoneAlertStatus(NimBLEClient* pClient);
+};


### PR DESCRIPTION
## Summary
- Add 5 new GATT service handlers: Generic Attribute (0x1801), HID (0x1812), Environmental Sensing (0x181A), Alert Notification (0x1811), Phone Alert Status (0x180E)
- Add `GenericDumpHandler` as a fallback that dumps characteristics (hex values, properties) for any unregistered/unknown service
- Extend `GATTServiceRegistry` with `registerFallback()` to route unmatched services to the generic handler

Closes #133

## New Services

| Service | UUID | Details |
|---------|------|---------|
| Generic Attribute | 0x1801 | Service Changed indication support |
| HID | 0x1812 | HID version, country code, protocol mode |
| Environmental Sensing | 0x181A | Temperature, humidity, pressure readings |
| Alert Notification | 0x1811 | Supported alert categories |
| Phone Alert Status | 0x180E | Ringer/vibrate/display status |
| **Fallback** | * | Hex dump of all characteristics for unknown services |

## Test plan
- [x] Build succeeds for ghostble environment
- [x] Scan devices with known GATT services (e.g. heart rate monitors, environmental sensors)
- [x] Verify fallback handler logs characteristics for devices with custom/unknown services
- [x] Confirm no regression in existing service handlers