### PR TITLE
Add device name fallback chain for speech bubble display

### DIFF
--- a/src/GATTServices/genericAccessService.cpp
+++ b/src/GATTServices/genericAccessService.cpp
@@ -42,11 +42,16 @@ String GenericAccessServiceHandler::readGenericAccessInfo(NimBLEClient* pClient)
         if (pChar->canRead()) {
             std::string value = pChar->readValue();
             
-            if (strcmp(charUUIDs[i], "2A01") == 0) {
+            if (strcmp(charUUIDs[i], "2A00") == 0) {
+                deviceName = String(value.c_str());
+                String val = deviceName;
+                accessInfoString += String(charNames[i]) + ": " + val + "\n";
+                LOG(LOG_GATT, "     " + String(charNames[i]) + ": " + val);
+            } else if (strcmp(charUUIDs[i], "2A01") == 0) {
                 if (value.size() >= 2) {
                     uint16_t appearance;
                     memcpy(&appearance, value.data(), sizeof(appearance));
-                    String appearanceName = getAppearanceName(appearance);
+                    appearanceName = getAppearanceName(appearance);
                     accessInfoString += "Appearance: " + appearanceName + " (0x" + String(appearance, HEX) + ")\n";
                     LOG(LOG_GATT, "     Appearance: " + appearanceName + " (0x" + String(appearance, HEX) + ")");
                 }

--- a/src/globals/globals.cpp
+++ b/src/globals/globals.cpp
@@ -71,6 +71,8 @@ String payload = "";
 String hexPayload = "";
 String spacedPayload = "";
 
+String deviceName = "";
+String appearanceName = "";
 String deviceInfoService = "";
 
 String lastConnectedDeviceInfo = "Noch kein Gerät verbunden.";

--- a/src/globals/globals.h
+++ b/src/globals/globals.h
@@ -70,6 +70,8 @@ extern String payload;
 extern String hexPayload;
 extern String spacedPayload;
 
+extern String deviceName;
+extern String appearanceName;
 extern String deviceInfoService;
 
 extern String lastConnectedDeviceInfo;

--- a/src/helper/showExpression.cpp
+++ b/src/helper/showExpression.cpp
@@ -179,13 +179,18 @@ void showGlassesExpressionTask(void* parameter) {
     }
     showFindingCounter(targetConnects, susDevice, allSpottedDevice);
 
-    if (localName.length() > 0 && !isSpeechBubbleActive) {
+    // Fallback chain: localName → deviceName → appearanceName
+    String bubbleText = localName;
+    if (bubbleText.length() == 0) bubbleText = deviceName;
+    if (bubbleText.length() == 0) bubbleText = appearanceName;
+
+    if (bubbleText.length() > 0 && !isSpeechBubbleActive) {
       clearSpeechBubble();
-      if(localName.length() > 14) {
-        localName = localName.substring(0, 11) + "...";
+      if(bubbleText.length() > 14) {
+        bubbleText = bubbleText.substring(0, 11) + "...";
       }
 
-      drawBubble(localName.c_str(), BUBBLE_X, BUBBLE_RECT_Y, WHITE, BUBBLE_BORDER_COLOR, BLACK);
+      drawBubble(bubbleText.c_str(), BUBBLE_X, BUBBLE_RECT_Y, WHITE, BUBBLE_BORDER_COLOR, BLACK);
 
       vTaskDelay(pdMS_TO_TICKS(3000));  // 3 Sekunden
     }
@@ -227,12 +232,17 @@ void showSadExpressionTask(void* parameter) {
                   nibblesSad, NIBBLESSAD_WIDTH, NIBBLESSAD_HEIGHT, 83, 56);
     showFindingCounter(targetConnects, susDevice, allSpottedDevice);
 
-    if (localName.length() > 0 && !isSpeechBubbleActive) {
+    // Fallback chain: localName → deviceName → appearanceName
+    String sadBubbleText = localName;
+    if (sadBubbleText.length() == 0) sadBubbleText = deviceName;
+    if (sadBubbleText.length() == 0) sadBubbleText = appearanceName;
+
+    if (sadBubbleText.length() > 0 && !isSpeechBubbleActive) {
       clearSpeechBubble();
-      if(localName.length() > 14) {
-        localName = localName.substring(0, 11) + "...";
+      if(sadBubbleText.length() > 14) {
+        sadBubbleText = sadBubbleText.substring(0, 11) + "...";
       }
-      drawBubble(localName.c_str(), BUBBLE_X, BUBBLE_RECT_Y, WHITE, BUBBLE_BORDER_COLOR, BLACK);
+      drawBubble(sadBubbleText.c_str(), BUBBLE_X, BUBBLE_RECT_Y, WHITE, BUBBLE_BORDER_COLOR, BLACK);
     }
 
     vTaskDelay(pdMS_TO_TICKS(2000));  // 2 Sekunden


### PR DESCRIPTION
## Summary
- Store **Device Name** (0x2A00) and **Appearance** (0x2A01) from Generic Access Service into globals
- Use a fallback chain in `showGlassesExpressionTask` and `showSadExpressionTask`: **localName → deviceName → appearanceName**
- Prevents truncating global strings by using local variables for the bubble text

## Test plan
- [x] Connect to a device that has no `localName` but exposes a Device Name via Generic Access Service — verify the speech bubble shows the Device Name
- [x] Connect to a device with neither `localName` nor Device Name — verify Appearance is shown
- [x] Connect to a device with `localName` set — verify it still takes priority
- [x] Verify names longer than 14 characters are truncated with "..."

Closes #139