### PR TITLE
scan crash in finder

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@ build_flags =
     -I src
 
 monitor_speed = 115200
-#monitor_filters = esp32_exception_decoder
+monitor_filters = esp32_exception_decoder
 lib_deps =
     m5stack/M5Cardputer
     m5stack/M5Unified

--- a/src/app/context/device_finder.cpp
+++ b/src/app/context/device_finder.cpp
@@ -5,6 +5,8 @@
 #include "app/context/scan_context.h"
 #include "ui/finder/finder_list_view.h"
 #include "infrastructure/logging/logger.h"
+#include "infrastructure/ble/ble_scanner.h"
+
 
 namespace DeviceFinder {
 
@@ -40,14 +42,7 @@ int count() { return count_; }
 const FoundDevice& get(int index) { return list_[index]; }
 
 void startFinderFlow() {
-    bool wasScanning = ScanContext::bleScanEnabled.load();
-    if (wasScanning) {
-        LOG(LOG_CONTROL, "Find Device — stopping main scan");
-        ScanContext::bleScanEnabled.store(false);
-        vTaskDelay(pdMS_TO_TICKS(300));
-    }
-
-    LOG(LOG_CONTROL, "Find Device — scanning 10s...");
+    LOG(LOG_CONTROL, "Find Device — scanning 5s...");
     scan5s();
 
     FinderListView::open();

--- a/src/app/context/scan_context.cpp
+++ b/src/app/context/scan_context.cpp
@@ -9,6 +9,7 @@ namespace ScanContext {
 // ------------------------------------------------------------
 std::atomic<bool> bleScanEnabled{false};
 std::atomic<bool> scanIsRunning{false};
+std::atomic<bool> scanCancelRequested{false};
 
 // ------------------------------------------------------------
 //  Found devices

--- a/src/app/context/scan_context.h
+++ b/src/app/context/scan_context.h
@@ -22,8 +22,9 @@ namespace ScanContext {
 // ------------------------------------------------------------
 //  Scan-Steuerung  (Core 0 schreibt, Core 1 liest → atomic)
 // ------------------------------------------------------------
-extern std::atomic<bool> bleScanEnabled;   // User hat Scan aktiviert
-extern std::atomic<bool> scanIsRunning;    // Scan-Schleife läuft gerade
+extern std::atomic<bool> bleScanEnabled;       // User hat Scan aktiviert
+extern std::atomic<bool> scanIsRunning;        // Scan-Schleife läuft gerade
+extern std::atomic<bool> scanCancelRequested;
 
 // ------------------------------------------------------------
 //  Gefundene Geräte

--- a/src/infrastructure/ble/ble_scanner.cpp
+++ b/src/infrastructure/ble/ble_scanner.cpp
@@ -273,6 +273,7 @@ void stopBleScan() {
     LOG(LOG_SCAN, "Stopping BLE scan...");
     NimBLEDevice::getScan()->stop();
     ScanContext::bleScanEnabled.store(false);
+    ScanContext::scanCancelRequested.store(true);
 }
 
 // ===========================================================================
@@ -915,6 +916,12 @@ void scanForDevices() {
     //  Per-device processing loop
     // ===================================================================
     for (int i = 0; i < results.getCount(); i++) {
+        // ── Cooporative abort — someone with exclusive access requested ──
+        if (ScanContext::scanCancelRequested.load()) {
+            LOG(LOG_SCAN, "Scan cancelled mid-loop (" + String(i) + "/" + String(results.getCount()) + " devices processed)");
+            break;
+        }
+
         dev = {};
         displayName.clear();
         const NimBLEAdvertisedDevice* device = results.getDevice(i);
@@ -1415,7 +1422,7 @@ void scanForDevices() {
         NimBLEDevice::deleteClient(pClient);
         pClient = nullptr;
         delay(1000);  // brief delay to ensure clean disconnection before next iteration
-    }  // end per-device loop
+    }   // end per-device loop
 
     // =======================================================================
     //  Scan summary
@@ -1464,5 +1471,6 @@ void scanForDevices() {
     // Clear any stale speech bubble that may have been skipped due to queuing
     clearSpeechBubble();
 
+    ScanContext::scanCancelRequested.store(false);
     ScanContext::scanIsRunning.store(false);
 }

--- a/src/ui/finder/approach_view.cpp
+++ b/src/ui/finder/approach_view.cpp
@@ -7,6 +7,7 @@
 #include "ui/finder/finder_list_view.h"
 
 #include "infrastructure/platform/hardware_config.h"
+#include "infrastructure/ble/ble_scanner.h"
 
 
 namespace ApproachView {
@@ -14,6 +15,7 @@ namespace ApproachView {
 // ── State ────────────────────────────────────────────────────
 static bool    open_          = false;
 static bool    staticDrawn_   = false;
+static bool    scanStopped_   = false;
 static String  targetMac_;
 static String  targetName_;
 static int8_t  smoothedRssi_  = -100;
@@ -44,7 +46,7 @@ static constexpr int GRID_STEP = 12;
 static int rssiToPercent(int8_t rssi) {
 
     //return constrain(map(rssi, -88, -40, 0, 100), 0, 100);
-    return constrain(map(rssi, -90, -42, 0, 100), 0, 100);
+    return constrain(map(rssi, -90, -30, 0, 100), 0, 100);
 }
 
 static unsigned long percentToBeepInterval(int pct) {
@@ -172,8 +174,14 @@ static void beepIfNeeded(int8_t rssi, bool found) {
 // ============================================================
 
 void open(const char* mac, const char* name) {
+    if (ScanContext::bleScanEnabled.load()) {
+        LOG(LOG_CONTROL, "Approach View — stopping main scan");
+        stopBleScan();
+    }
+
     open_          = true;
     staticDrawn_   = false;
+    scanStopped_   = false;
     targetMac_     = mac;
     targetName_    = name;
     smoothedRssi_  = -100;
@@ -185,10 +193,19 @@ void open(const char* mac, const char* name) {
 
 void close() {
     open_ = false;
-    FinderListView::open();
+    //FinderListView::open();
+    //FinderListView::draw();
+    MenuController::open();
 }
 
 bool isOpen() { return open_; }
+
+static void drawPausingMessage() {
+    M5.Lcd.fillRect(0, 108, 240, 14, COL_SCREEN_BG);
+    M5.Lcd.setTextColor(0xFFE0, COL_SCREEN_BG);   // gelb, gut sichtbar
+    M5.Lcd.setCursor(4, 110);
+    M5.Lcd.print("Pausing main scan...");
+}
 
 void update() {
     if (!open_) return;
@@ -196,6 +213,31 @@ void update() {
     if (!staticDrawn_) {
         drawStatic();
         staticDrawn_ = true;
+    }
+
+    if (!scanStopped_) {
+        if (ScanContext::bleScanEnabled.load()) {
+            LOG(LOG_CONTROL, "Approach View — stopping main scan");
+            stopBleScan();
+        }
+
+        LOG(LOG_CONTROL, "Approach View — waiting, scanIsRunning=" + String(ScanContext::scanIsRunning.load()));
+
+        unsigned long waitStart = millis();
+        int dots = 0;
+        while (ScanContext::scanIsRunning.load() && (millis() - waitStart < 8000)) {
+            M5.Lcd.fillRect(0, 108, 240, 14, COL_SCREEN_BG);
+            M5.Lcd.setTextColor(0xFFE0, COL_SCREEN_BG);
+            M5.Lcd.setCursor(4, 110);
+            M5.Lcd.print("Pausing main scan");
+            for (int i = 0; i < (dots % 4); i++) M5.Lcd.print(".");
+            dots++;
+            vTaskDelay(pdMS_TO_TICKS(250));
+        }
+
+        scanStopped_  = true;
+        lastScanTime_ = millis();
+        return;
     }
 
     beepIfNeeded(smoothedRssi_, lastFound_);
@@ -222,7 +264,7 @@ void update() {
     }
 
     if (found) {
-        smoothedRssi_ = (smoothedRssi_ * 3 + rssi) / 4;   // Glättung
+        smoothedRssi_ = (smoothedRssi_ * 3 + rssi) / 4;
     }
     lastFound_ = found;
 

--- a/src/ui/finder/finder_list_view.cpp
+++ b/src/ui/finder/finder_list_view.cpp
@@ -16,6 +16,7 @@
 #include "assets/nibblesHappy.h"
 
 #include "infrastructure/platform/hardware_config.h"
+#include "infrastructure/ble/ble_scanner.h"
 
 
 namespace FinderListView {
@@ -24,6 +25,11 @@ static bool open_ = false;
 static int  cursorIdx_ = 0;
 
 void open() {
+    if (ScanContext::bleScanEnabled.load()) {
+        LOG(LOG_CONTROL, "Approach View — stopping main scan");
+        stopBleScan();
+    }
+    
     open_ = true;
     cursorIdx_ = 0;
     draw();
@@ -47,14 +53,8 @@ bool isOpen() { return open_; }
 void refresh() {
     if (!open_) return;
 
-    //LOG(LOG_CONTROL, "Finder — refreshing scan");
+    LOG(LOG_CONTROL, "Finder — refreshing scan");
     drawScanning();
-
-    bool wasScanning = ScanContext::bleScanEnabled.load();
-    if (wasScanning) {
-        ScanContext::bleScanEnabled.store(false);
-        vTaskDelay(pdMS_TO_TICKS(300));
-    }
 
     DeviceFinder::scan5s();
 

--- a/src/ui/menu/menu_controller.cpp
+++ b/src/ui/menu/menu_controller.cpp
@@ -238,7 +238,7 @@ static void buildItems() {
 
     // im buildItems():
     section("SUSPICIOUS DEVICES");
-    action("View Sus Log", []() {
+    action("View Sus Device List", []() {
         MenuController::closeSilent();
         SusDeviceView::open();
     });


### PR DESCRIPTION
if main scan is not stopped correct the finder scan crashed. First stop main scan then run device finder.