### PR TITLE
fix(ble): strip NimBLE's 0x prefix in extract16BitUUID

### DIFF
--- a/src/infrastructure/ble/handler/sdo_handlers.cpp
+++ b/src/infrastructure/ble/handler/sdo_handlers.cpp
@@ -100,7 +100,12 @@ void SdoHandlers::handleMatter(const SdoContext* ctx) {
 }
 
 bool SdoHandlers::extract16BitUUID(const NimBLEUUID& uuid, uint16_t& out) {
-    std::string s = uuid.toString();  // z.B. "0000fffa-0000-1000-8000-00805f9b34fb"
+    std::string s = uuid.toString();  // z.B. "0xfffa" oder "0000fffa-0000-1000-8000-00805f9b34fb"
+
+    // NimBLE prefixes 16-bit UUIDs with "0x" (see ble_uuid_to_str) — strip it
+    if (s.rfind("0x", 0) == 0) {
+        s = s.substr(2);
+    }
 
     // Fall 1: kurze Form "fffa"
     if (s.length() == 4) {


### PR DESCRIPTION
NimBLE's `ble_uuid_to_str()` formats 16-bit UUIDs as `0x%04x` (e.g. `0xfeaa`), but
`SdoHandlers::extract16BitUUID()` only matched a bare 4-char string ("feaa") or the
full 36-char 128-bit form — never the 6-char "0x"-prefixed short form NimBLE actually
produces. So it always returned false, silently disabling every 16-bit-UUID-gated
detection path (SDO drone/FIDO/Matter detection), without any error or log line.

Found while building a new detection feature that also depends on this function.

Fix: strip the "0x" prefix before the length check.
