### PR TITLE
feat(detection): passive Google Find My (FMDN) tracker detection via …

### DIFF
--- a/src/core/parsing/fmdn_parser.cpp
+++ b/src/core/parsing/fmdn_parser.cpp
@@ -1,0 +1,23 @@
+#include "fmdn_parser.h"
+
+namespace FmdnParser {
+
+FmdnResult parse(uint16_t serviceUuid, const uint8_t* data, size_t len) {
+    FmdnResult result;
+
+    if (serviceUuid != UUID_EDDYSTONE && serviceUuid != UUID_FAST_PAIR)
+        return result;
+    if (data == nullptr || len < 1)
+        return result;
+
+    const uint8_t frameType = data[0];
+    if (frameType != FRAME_NORMAL && frameType != FRAME_UNWANTED)
+        return result;  // real Eddystone (0x00/0x10/0x20/0x30) falls through here
+
+    result.detected         = true;
+    result.frameType        = frameType;
+    result.unwantedTracking = (frameType == FRAME_UNWANTED);
+    return result;
+}
+
+}  // namespace FmdnParser

--- a/src/core/parsing/fmdn_parser.h
+++ b/src/core/parsing/fmdn_parser.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+// ===========================================================================
+//  Google Find My Device network (FMDN) advertising detection.
+//
+//  Non-Apple trackers (Motorola Moto Tag, Novoo, Chipolo, Pebblebee) broadcast
+//  in Google's Find My Device network. Google documents this under the Fast Pair
+//  service UUID 0xFE2C, but real devices (verified by capture) send the frame
+//  under the Eddystone UUID 0xFEAA instead — 0xFE2C only appears as a GATT
+//  service on connect. The frame starts with a frame-type byte:
+//      0x40 = normal (owner nearby)
+//      0x41 = unwanted-tracking mode (separated from owner — anti-stalking)
+//  followed by a rotating ~20-byte ephemeral ID.
+//
+//  Collision-free with real Eddystone: its frame types are 0x00/0x10/0x20/0x30,
+//  never 0x40/0x41. Purely passive — no connection required.
+// ===========================================================================
+
+namespace FmdnParser {
+
+constexpr uint16_t UUID_EDDYSTONE = 0xFEAA;  // observed FMDN broadcast slot
+constexpr uint16_t UUID_FAST_PAIR = 0xFE2C;  // documented FMDN slot
+constexpr uint8_t  FRAME_NORMAL   = 0x40;
+constexpr uint8_t  FRAME_UNWANTED = 0x41;    // separated tracker (stalking-relevant)
+
+struct FmdnResult {
+    bool    detected         = false;
+    bool    unwantedTracking = false;  // frame type 0x41
+    uint8_t frameType        = 0;
+};
+
+// serviceUuid: the 16-bit service-data UUID; data/len: the raw payload bytes.
+FmdnResult parse(uint16_t serviceUuid, const uint8_t* data, size_t len);
+
+}  // namespace FmdnParser

--- a/src/infrastructure/ble/ble_scanner.cpp
+++ b/src/infrastructure/ble/ble_scanner.cpp
@@ -18,6 +18,7 @@
 
 #include "core/parsing/appearance_parser.h"
 #include "core/parsing/binary_format_detector.h"
+#include "core/parsing/fmdn_parser.h"
 
 #include "gattServices/notify_handler.h"
 
@@ -665,6 +666,36 @@ static bool parseDeviceInfo(
                     if (result.uuid == 0xFFF6) SdoHandlers::handleMatter(&ctx);
                 }
             }    
+
+            // ============================================================
+            // GOOGLE FIND MY DEVICE (FMDN) TRACKER DETECTION
+            // Passive: Moto Tag / Novoo / Chipolo broadcast under Eddystone
+            // UUID 0xFEAA with frame byte 0x40 (normal) / 0x41 (unwanted).
+            // ============================================================
+            if (hasUuid16) {
+                FmdnParser::FmdnResult fmdn = FmdnParser::parse(
+                    uuid16, (const uint8_t*)svcData.data(), svcData.size());
+
+                if (fmdn.detected) {
+                    const char* fmdnLabel = fmdn.unwantedTracking
+                        ? "FMDN Unwanted Track"     // 0x41 – separated tracker
+                        : "Google Find My";         // 0x40 – owner nearby
+
+                    LOG(LOG_TARGET, devTag + "Google Find My tracker detected"
+                        + (fmdn.unwantedTracking ? " (UNWANTED TRACKING MODE)" : "")
+                        + "\n   Address:  " + String(ScanContext::addrStr.c_str())
+                        + "\n   RSSI:     " + String(ScanContext::rssi.load()) + " dBm");
+
+                    isSecurityOrTrackingDevice = true;
+                    ScanContext::susDevice++;
+                    DeviceContext::xpManager.awardXP(fmdn.unwantedTracking ? 5.0f : 3.0f);
+
+                    SusLog::add(fmdnLabel, ScanContext::addrStr.c_str(),
+                                (int8_t)ScanContext::rssi.load());
+
+                    nibblesSpeechShowCustom(fmdn.unwantedTracking ? "Stalker?!" : "FindMy tag");
+                }
+            }
 
             // PwnBeacon service data payload
             if (svcDataUUID.equals(NimBLEUUID(PWNBEACON_SERVICE_UUID))) {

--- a/test/test_fmdn/impl.cpp
+++ b/test/test_fmdn/impl.cpp
@@ -1,0 +1,3 @@
+// Pulls in the implementation so the linker can find the symbols.
+// No Arduino hardware is used in these files.
+#include "core/parsing/fmdn_parser.cpp"

--- a/test/test_fmdn/test_fmdn_parser.cpp
+++ b/test/test_fmdn/test_fmdn_parser.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+#include "core/parsing/fmdn_parser.h"
+
+// Novoo frame from real capture: "40 F4 8E 0D ..." under UUID 0xFEAA
+TEST(FmdnParser, DetectsNormalFrameUnderEddystone) {
+    const uint8_t data[] = {0x40, 0xF4, 0x8E, 0x0D, 0x40};
+    auto r = FmdnParser::parse(0xFEAA, data, sizeof(data));
+    EXPECT_TRUE(r.detected);
+    EXPECT_FALSE(r.unwantedTracking);
+}
+
+TEST(FmdnParser, DetectsUnwantedTrackingFrame) {
+    const uint8_t data[] = {0x41, 0x01, 0x02};
+    auto r = FmdnParser::parse(0xFEAA, data, sizeof(data));
+    EXPECT_TRUE(r.detected);
+    EXPECT_TRUE(r.unwantedTracking);
+}
+
+TEST(FmdnParser, AlsoAcceptsFastPairUuid) {
+    const uint8_t data[] = {0x40, 0x00};
+    EXPECT_TRUE(FmdnParser::parse(0xFE2C, data, sizeof(data)).detected);
+}
+
+TEST(FmdnParser, IgnoresRealEddystoneFrameTypes) {
+    const uint8_t data[] = {0x10, 0x00, 0xAA};  // Eddystone-URL
+    EXPECT_FALSE(FmdnParser::parse(0xFEAA, data, sizeof(data)).detected);
+}
+
+TEST(FmdnParser, IgnoresUnrelatedUuidAndEmpty) {
+    const uint8_t data[] = {0x40};
+    EXPECT_FALSE(FmdnParser::parse(0xFEED, data, sizeof(data)).detected);
+    EXPECT_FALSE(FmdnParser::parse(0xFEAA, nullptr, 0).detected);
+}

--- a/test/test_fmdn/test_main.cpp
+++ b/test/test_fmdn/test_main.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    _Exit(result);
+}


### PR DESCRIPTION
…Eddystone 0xFEAA frame type

Adds passive detection of Google Find My Device network (FMDN) trackers
(Motorola Moto Tag, Novoo, Chipolo, Pebblebee, ...).

Background: these devices document their protocol under Fast Pair UUID
0xFE2C, but in practice broadcast the advertising frame under the Eddystone
UUID 0xFEAA (verified by capture). The first byte of the service data is
the frame type: 0x40 = normal (owner nearby), 0x41 = unwanted tracking
(separated from owner, anti-stalking). Collision-free with real Eddystone,
whose frame types are 0x00/0x10/0x20/0x30.

- New core/parsing/fmdn_parser.{h,cpp} — pure, Arduino-free, native-testable
- Hook in ble_scanner.cpp mirroring the existing Apple Find My detection path
- test/test_fmdn — 5 GoogleTest cases against real captured Novoo bytes

Live-verified against a real Novoo tag (GATT serial matches a device
captured earlier). Note: full live detection currently requires #285
— extract16BitUUID returns false without that fix, so this hook never fires
at runtime (it still compiles and the unit tests pass either way, since
those exercise the parser directly).

Tested live on M5StickS3 (env:ghostble_sticks3). I don't have Cardputer 
hardware to test on — env:ghostble builds successfully but hasn't been runtime-verified

Known limitation, tracked separately: BLE devices with sparse advertisements
(no manufacturer data / service UUID list / appearance) can collide into the
same default SoftFingerprint dedup bucket and get silently skipped after the
first such device is seen — affects FMDN trackers among others. Filing as a
separate issue, out of scope here.
